### PR TITLE
config: Small settings for working in the project on a package

### DIFF
--- a/osdc.Rproj
+++ b/osdc.Rproj
@@ -2,14 +2,14 @@ Version: 1.0
 
 RestoreWorkspace: No
 SaveWorkspace: No
-AlwaysSaveHistory: Default
+AlwaysSaveHistory: No
 
 EnableCodeIndexing: Yes
 UseSpacesForTab: Yes
 NumSpacesForTab: 2
 Encoding: UTF-8
 
-RnwWeave: Sweave
+RnwWeave: knitr
 LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
@@ -18,3 +18,8 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace
+
+MarkdownWrap: Column
+MarkdownWrapAtColumn: 72
+MarkdownCanonical: Yes


### PR DESCRIPTION
Make it so we can build the documentation with `Ctrl-Shift-B` (the `PackageRoxygenize` line), make it so Markdown gets reformatted into canonical mode.