### PR TITLE
feat: :sparkles: workflow that assigns PR author as assignee

### DIFF
--- a/.github/workflows/auto-author-assign.yaml
+++ b/.github/workflows/auto-author-assign.yaml
@@ -1,0 +1,16 @@
+# .github/workflows/auto-author-assign.yml
+# https://github.com/marketplace/actions/auto-author-assign
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.1.0


### PR DESCRIPTION
This PR adds a GitHub Action that automatically adds the author of the PR as assignee. 

Closes #38