### PR TITLE
Build/add recommended vscode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,18 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"jebbs.plantuml",
+		"DavidAnson.vscode-markdownlint",
+		"GitHub.vscode-pull-request-github",
+		"quarto.quarto",
+		"vivaxy.vscode-conventional-commits",
+		"pshaddel.conventional-branch",
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,14 @@
 {
-    "conventional-branch.type": [
+  "files.autoSave": "onFocusChange",
+  "editor.tabSize": 2,
+  "editor.wordWrap": "off",
+  "editor.formatOnSave": true,
+  "git.autofetch": false,
+  "quarto.visualEditor.markdownWrap": "column",
+  "quarto.visualEditor.markdownWrapColumn": 72,
+  "editor.tabCompletion": "on",
+  "editor.snippetSuggestions": "inline",
+  "conventional-branch.type": [
       "build", // Changes that affect the build system or external dependencies
       "ci", // Changes to our CI configuration files and scripts
       "docs", // Documentation only changes
@@ -10,8 +19,5 @@
       "test", // Adding missing tests or correcting existing tests
       "chore", // Misc things, like renaming or deleting files
     ],
-    "conventional-branch.format": "{Type}/{Branch}",
-    "[python]": {
-      "editor.defaultFormatter": "charliermarsh.ruff"
-    }
+  "conventional-branch.format": "{Type}/{Branch}",
   }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+    "conventional-branch.type": [
+      "build", // Changes that affect the build system or external dependencies
+      "ci", // Changes to our CI configuration files and scripts
+      "docs", // Documentation only changes
+      "feat", // A new feature
+      "fix", // A bug fix
+      "refactor", // A code change that neither fixes a bug nor adds a feature
+      "style", // Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+      "test", // Adding missing tests or correcting existing tests
+      "chore", // Misc things, like renaming or deleting files
+    ],
+    "conventional-branch.format": "{Type}/{Branch}",
+    "[python]": {
+      "editor.defaultFormatter": "charliermarsh.ruff"
+    }
+  }


### PR DESCRIPTION
For documentation, I think it's nice to work in VS Code (that's at least my preferred editor). 

So I have added a some of the VS Code extensions (and the settings) that we use in Seedcase. 

Thoughts? 