### PR TITLE
ci: improve action build process

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,12 +1,9 @@
+name: R-CMD-check
+
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
-
-name: R-CMD-check
+  workflow_call:
 
 jobs:
   R-CMD-check:

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   check:
-    uses: .github/workflows/R-CMD-check.yaml@main
+    uses: ./.github/workflows/R-CMD-check.yaml@main
 
   coverage:
-    uses: .github/workflows/test-coverage.yaml@main
+    uses: ./.github/workflows/test-coverage.yaml@main
     needs: check
 
   deploy:
-    uses: .github/workflows/pkgdown.yaml@main
+    uses: ./.github/workflows/pkgdown.yaml@main
     needs: coverage

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -1,0 +1,24 @@
+name: Test, build, and deploy
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+jobs:
+  check:
+    uses: .github/workflows/R-CMD-check.yaml@main
+
+  coverage:
+    uses: .github/workflows/test-coverage.yaml@main
+    needs: check
+
+  deploy:
+    uses: .github/workflows/pkgdown.yaml@main
+    needs: coverage

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -20,5 +20,7 @@ jobs:
     needs: check
 
   deploy:
+    permissions:
+      contents: write
     uses: ./.github/workflows/pkgdown.yaml
     needs: coverage

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   check:
-    uses: ./.github/workflows/R-CMD-check.yaml@main
+    uses: ./.github/workflows/R-CMD-check.yaml
 
   coverage:
-    uses: ./.github/workflows/test-coverage.yaml@main
+    uses: ./.github/workflows/test-coverage.yaml
     needs: check
 
   deploy:
-    uses: ./.github/workflows/pkgdown.yaml@main
+    uses: ./.github/workflows/pkgdown.yaml
     needs: coverage

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,15 +1,9 @@
+name: Build website
+
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
-  release:
-    types: [published]
-  workflow_dispatch:
-
-name: pkgdown
+  workflow_call:
 
 jobs:
   pkgdown:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,12 +1,9 @@
+name: Test Coverage
+
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
-
-name: test-coverage
+  workflow_call:
 
 jobs:
   test-coverage:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 <!-- badges: start -->
 
-[![R-CMD-check](https://github.com/steno-aarhus/osdc/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/steno-aarhus/osdc/actions/workflows/R-CMD-check.yaml)
-[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![R-CMD-check](https://github.com/steno-aarhus/osdc/actions/workflows/build-package.yaml/badge.svg)](https://github.com/steno-aarhus/osdc/actions/workflows/build-package.yaml)
+[![Lifecycle:
+experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+
 <!-- badges: end -->
 
 The goal of *osdc* is to expose an algorithm for classifying diabetes
@@ -16,12 +18,12 @@ it, rather than code-based descriptions (e.g. the [Register of Selected
 Chronic
 Diseases](https://www.esundhed.dk/-/media/Files/Publikationer/Emner/Operationer-og-diagnoser/Udvalgte-kroniske-sygdomme-svaere-psykiske-lidelser/Algoritmer-for-Udvalgte-Kroniske-Sygdomme-og-svre-psykiske-lidelser-RUKS-2022.ashx).
 
-In this project, we aim to make it easier and more explicit to
-classify type 1 and type 2 diabetes within a Danish register context.
-The original implementation of the algorithm is validated in a
-peer-reviewed publication [here](https://doi.org/10.2147/clep.s407019),
-but we expect to make tweaks to the algorithm over time. Any changes
-will be transparent in the *osdc* repository.
+In this project, we aim to make it easier and more explicit to classify
+type 1 and type 2 diabetes within a Danish register context. The
+original implementation of the algorithm is validated in a peer-reviewed
+publication [here](https://doi.org/10.2147/clep.s407019), but we expect
+to make tweaks to the algorithm over time. Any changes will be
+transparent in the *osdc* repository.
 
 ## Installation
 


### PR DESCRIPTION
Right now there are three Actions that run all at once. They often fail, which means I get three emails saying they failed. It makes more sense that they run in sequence, so I converted the existing ones into reusable actions (`workflow_call:`) and created one that sets them all in sequence (first `check`, then `coverage`, then `deploy`).