### PR TITLE
ci: add testing package dependencies

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,6 +23,8 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
-          needs: check
+          needs:
+            - check
+            - tests
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
The Action needs the package dependencies that is only used when testing. Very small change.