### PR TITLE
fix: :art: add space before register_abbrev

### DIFF
--- a/vignettes/design.Rmd
+++ b/vignettes/design.Rmd
@@ -150,7 +150,7 @@ registers in order for the package to classify diabetes status:
 
 ```{r, echo=FALSE}
 variable_description |> 
-  mutate(Register = paste0(register_name, "(", register_abbrev, ")")) |> 
+  mutate(Register = paste0(register_name, " (", register_abbrev, ")")) |> 
   select(Register, Variable = variable_name) |> 
   knitr::kable()
 ```


### PR DESCRIPTION
Before: 
![Screenshot 2024-05-16 at 13 43 20](https://github.com/steno-aarhus/osdc/assets/40836345/38f44c57-3dcb-4b7e-bcda-7b4534db911f)

Now: 
![Screenshot 2024-05-16 at 13 42 45](https://github.com/steno-aarhus/osdc/assets/40836345/c2269e4a-5c80-467e-abf4-8a11d6f98d7b)

I know it's a minor thing, but it annoyed me :)