### PR TITLE
fix: remove formatOnSave to avoid VS code reformatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
   "files.autoSave": "onFocusChange",
   "editor.tabSize": 2,
   "editor.wordWrap": "off",
-  "editor.formatOnSave": true,
   "git.autofetch": false,
   "quarto.visualEditor.markdownWrap": "column",
   "quarto.visualEditor.markdownWrapColumn": 72,


### PR DESCRIPTION
... which is different from RStudio reformatting.

I have been fighting VS Code on the autosave and ended up doing this locally, so I thought I would add it here too. 