### PR TITLE
docs: :memo: add details on HbA1c inclusion criteria

### DIFF
--- a/vignettes/function-flow.Rmd
+++ b/vignettes/function-flow.Rmd
@@ -92,12 +92,17 @@ outputs.](images/function-flow-population.png)
 
 ### Inclusion events
 
-#### HbA1c tests above 48 mmol/mol
+#### HbA1c tests above the diagnosis cut-off value (48 mmol/mol or 6.5%)
 
 The function `include_hba1c()` uses `lab_forsker` as the input data to
-extract all events of tests above 48 mmol/mol.
+extract all events of HbA1c tests above the diagnosis cut-off value.
 
-<!-- TODO: Add details on how this filtering should be done -->
+Since the HbA1c diagnosis cut-off value depends on the kind of test that is
+used, the inclusion event is defined as follows:
+
+-   For HbA1c IFCC (NPU03835), we include values \>= 6.5 %.
+-   For HbA1c DCCT (NPU27300), we include values \>= 48 mmol/mol.
+
 
 #### Hospital diagnosis of diabetes
 

--- a/vignettes/function-flow.Rmd
+++ b/vignettes/function-flow.Rmd
@@ -108,6 +108,10 @@ used, the inclusion event is defined as follows:
 -   For HbA1c IFCC (NPU03835), we include values \>= 6.5 %.
 -   For HbA1c DCCT (NPU27300), we include values \>= 48 mmol/mol.
 
+```{r filter hba1c inclusion criteria and show logic in table, echo=FALSE}
+algorithm_hba1c <- algorithm |> filter(name=="hba1c")
+knitr::kable(algorithm_hba1c)
+```
 
 #### Hospital diagnosis of diabetes
 

--- a/vignettes/function-flow.Rmd
+++ b/vignettes/function-flow.Rmd
@@ -92,6 +92,11 @@ outputs.](images/function-flow-population.png)
 
 ### Inclusion events
 
+```{r Add algorithm data, include=FALSE}
+library(dplyr); library(knitr)
+load("../data/algorithm.Rda")
+```
+
 #### HbA1c tests above the diagnosis cut-off value (48 mmol/mol or 6.5%)
 
 The function `include_hba1c()` uses `lab_forsker` as the input data to

--- a/vignettes/function-flow.Rmd
+++ b/vignettes/function-flow.Rmd
@@ -92,9 +92,9 @@ outputs.](images/function-flow-population.png)
 
 ### Inclusion events
 
-```{r Add algorithm data, include=FALSE}
-library(dplyr); library(knitr)
-load("../data/algorithm.Rda")
+```{r, include=FALSE}
+library(dplyr)
+library(osdc)
 ```
 
 #### HbA1c tests above the diagnosis cut-off value (48 mmol/mol or 6.5%)
@@ -108,9 +108,10 @@ used, the inclusion event is defined as follows:
 -   For HbA1c IFCC (NPU03835), we include values \>= 6.5 %.
 -   For HbA1c DCCT (NPU27300), we include values \>= 48 mmol/mol.
 
-```{r filter hba1c inclusion criteria and show logic in table, echo=FALSE}
-algorithm_hba1c <- algorithm |> filter(name=="hba1c")
-knitr::kable(algorithm_hba1c)
+```{r, echo=FALSE}
+algorithm |> 
+	filter(name=="hba1c") |>
+	knitr::kable(caption = "Algorithm used in the implementation for including HbA1c.")
 ```
 
 #### Hospital diagnosis of diabetes


### PR DESCRIPTION
## Description

Based on what has already been implemented for the HbA1c inclusion criteria, I have updated the documentation of this criteria in the function flow vignette. 

I have also added the `algorithm.Rda` to be able to show the logic in a table. I thought it might be nice to visualise it and make it rely directly on the algorithm logic that we implement.

However: 

1) I have probably added it in a very non-ideal / non-Luke-approved manner
2) I ended up writing it all in the text as well, so maybe it's not necessary to include at all?

