### PR TITLE
fix: 🐛 change honuge format to yyww

### DIFF
--- a/data-raw/simulate-data.R
+++ b/data-raw/simulate-data.R
@@ -219,7 +219,10 @@ create_fake_drug_name <- function(atc) {
 #' to_yyww("2020-12-01")
 #' to_yyww(c("2020-01-12", "1995-04-19"))
 to_yyww <- function(x) {
-  paste0(stringr::str_sub(lubridate::isoyear(lubridate::as_date(x)), -2), lubridate::isoweek(lubridate::as_date(x)))
+  paste0(
+    stringr::str_sub(lubridate::isoyear(lubridate::as_date(x)), -2),
+    sprintf("%02d", lubridate::isoweek(lubridate::as_date(x)))
+  )
 }
 
 #' Transform date(s) to the format yyyymmdd
@@ -316,7 +319,7 @@ insert_false_metformin <- function(data, proportion = 0.05) {
         )
       )
   } else {
-  data
+    data
   }
 }
 

--- a/data-raw/simulate-data.R
+++ b/data-raw/simulate-data.R
@@ -72,7 +72,7 @@ create_fake_icd <- function(n, date = NULL) {
 
 #' @description
 #' ICD-8 is the 8th revision of the International Classification of Diseases.
-#' 
+#'
 #' @param n The number of ICD-8 diagnoses to generate.
 #'
 #' @return A character vector of ICD-8 diagnoses.
@@ -90,7 +90,7 @@ create_fake_icd8 <- function(n) {
 #'
 #' @description
 #' ICD-10 is the 10th revision of the International Classification of Diseases.
-#' 
+#'
 #' @param n An integer determining how many diagnoses to create.
 #'
 #' @return A character vector of ICD-10 diagnoses.
@@ -110,7 +110,7 @@ create_fake_icd10 <- function(n) {
 #' @description
 #' Anatomical Therapeutic Chemical (ATC) codes are unique medicine codes
 #' based on on what organ or system it works on and how it works.
-#' 
+#'
 #' @param n The number of random ATC codes to generate.
 #'
 #' @return A character vector of ATC codes.
@@ -161,7 +161,7 @@ create_padded_integer <- function(n, length) {
 #' @description
 #' Nomenclature for Properties and Units (NPUs) are codes that identifies
 #' laboratory results.
-#' 
+#'
 #' @param n The number of NPUs to create.
 #'
 #' @return A character vector.
@@ -209,17 +209,17 @@ create_fake_drug_name <- function(atc) {
     sample(length(atc), replace = TRUE)
 }
 
-#' Transform date(s) to the format wwyy
+#' Transform date(s) to the format yyww
 #'
 #' @param x A date or a vector of dates.
 #'
-#' @return A vector of dates in the format wwyy.
+#' @return A vector of dates in the format yyww.
 #'
 #' @examples
-#' to_wwyy("2020-12-01")
-#' to_wwyy(c("2020-01-12", "1995-04-19"))
-to_wwyy <- function(x) {
-  paste0(lubridate::isoweek(lubridate::as_date(x)), stringr::str_sub(lubridate::isoyear(lubridate::as_date(x)), -2))
+#' to_yyww("2020-12-01")
+#' to_yyww(c("2020-01-12", "1995-04-19"))
+to_yyww <- function(x) {
+  paste0(stringr::str_sub(lubridate::isoyear(lubridate::as_date(x)), -2), lubridate::isoweek(lubridate::as_date(x)))
 }
 
 #' Transform date(s) to the format yyyymmdd

--- a/data-raw/simulation-definitions.csv
+++ b/data-raw/simulation-definitions.csv
@@ -28,11 +28,11 @@ diagnoser,senere_afkraeftet,string,Binary natural language,"draw_categorical(N =
 sysi,pnr,string,12 digits zero-padded,"create_padded_integer(N, 12)",,
 sysi,barnmak,integer,binary,"draw_binary(0.1, N = N)",0 is no,
 sysi,speciale,string,5 digits,"create_padded_integer(N, 5)","""^54"" is diabetes-specific podiatrist service",
-sysi,honuge,string,"4 digits: WWyy (2 digits week number, 2 digits year)","to_wwyy(create_fake_date(N, from = ""1990-01-01"", to = ""2004-12-31""))",,
+sysi,honuge,string,"4 digits: yyww (2 digits year, 2 digits week number)","to_yyww(create_fake_date(N, from = ""1990-01-01"", to = ""2004-12-31""))",,
 sssy,pnr,string,12 digits zero-padded,"create_padded_integer(N, 12)",,
 sssy,barnmak,integer,binary,"draw_binary(0.1, N = N)",0 is no,
 sssy,speciale,string,5 digits,"create_padded_integer(N, 5)","""^54"" is diabetes-specific podiatrist service",
-sssy,honuge,string,"4 digits: WWyy (2 digits week number, 2 digits year)","to_wwyy(create_fake_date(N, from = ""2005-01-01""))",,
+sssy,honuge,string,"4 digits: yyww (2 digits year, 2 digits week number)","to_yyww(create_fake_date(N, from = ""2005-01-01""))",,
 lab_forsker,patient_cpr,string,12 digits zero-padded,"create_padded_integer(N, 12)",,
 lab_forsker,samplingdate,date,YYYYMMDD,"to_yyyymmdd(create_fake_date(N, from = ""2011-01-01""))",,
 lab_forsker,analysiscode,string,8 digit NPU code,create_fake_npu(N),NPU27300 is HbA1c in modern units (IFCC),NPU03835 is HbA1c in old units

--- a/data-raw/variable-description.csv
+++ b/data-raw/variable-description.csv
@@ -28,11 +28,11 @@ Landspatientregisterets diagnosetabel (LPR3),diagnoser,2019,NA,senere_afkraeftet
 Sygesikringsregisteret,sysi,1990,2005,pnr,pseudonymiseret cpr-nummer,pseudonymised social security number,NA
 Sygesikringsregisteret,sysi,1990,2005,barnmak,blev ydelse ydet til patientens barn?,was the service provided to the patient's child?,NA
 Sygesikringsregisteret,sysi,1990,2005,speciale,ydelsens honoreringskode,billing code of the service (fully specified),NA
-Sygesikringsregisteret,sysi,1990,2005,honuge,uge og aar for ydelse,week and year of service,NA
+Sygesikringsregisteret,sysi,1990,2005,honuge,aar og uge for ydelse,year and week of service,NA
 Sygesikringsregisteret,sssy,2005,NA,pnr,pseudonymiseret cpr-nummer,pseudonymised social security number,NA
 Sygesikringsregisteret,sssy,2005,NA,barnmak,blev ydelse ydet til patientens barn?,was the service provided to the patient's child?,NA
 Sygesikringsregisteret,sssy,2005,NA,speciale,ydelsens honoreringskode (fuldt specificeret),billing code of the service (fully specified),NA
-Sygesikringsregisteret,sssy,2005,NA,honuge,uge og aar for ydelse,week and year of service,NA
+Sygesikringsregisteret,sssy,2005,NA,honuge,aar og uge for ydelse,year and week of service,NA
 Laboratoriedatabasens forskertabel,lab_forsker,2011,NA,patient_cpr,pseudonymiseret cpr-nummer,pseudonymised social security number,NA
 Laboratoriedatabasens forskertabel,lab_forsker,2011,NA,samplingdate,dato for proevetagning,date of sampling,NA
 Laboratoriedatabasens forskertabel,lab_forsker,2011,NA,analysiscode,analysens NPU-kode,NPU code of analysis,NPU03835 is HbA1c in old units


### PR DESCRIPTION
This PR changes the format of the variable `honuge` from `wwyy` to `yyww`, since that's the correct format, according to [DST](https://www.dst.dk/da/TilSalg/Forskningsservice/Dokumentation/hoejkvalitetsvariable/sygesikring---ydelser/honuge). I have changed this in the data simulation and variable description. 

I have also added a zero padding of the week number, since that's how it's described by DST (in the link provided above: 
> HONUGE er angivet som ÅÅUU, altså 2-cifret årstal efterfulgt af ugenummer 01 til 52 (evt. 53).

NOTE: this does not update the simulated data. I'll add that to the targets pipeline in a separate PR and update it there.