### PR TITLE
fix: :bug: misc fixes to successfully run `r-cmd-check`

### DIFF
--- a/R/include-gld-purchases.R
+++ b/R/include-gld-purchases.R
@@ -2,6 +2,8 @@
 #'
 #' See [algorithm] for the logic used to filter these patients.
 #'
+#' @param lmdb The LMDB register.
+#'
 #' @return The same type as the input data, default as a [tibble::tibble()].
 #' @keywords internal
 #'

--- a/man/get_algorithm_logic.Rd
+++ b/man/get_algorithm_logic.Rd
@@ -4,7 +4,7 @@
 \alias{get_algorithm_logic}
 \title{Get the criteria algorithmic logic and convert to an R logic condition.}
 \usage{
-get_algorithm_logic(criteria)
+get_algorithm_logic(criteria, algorithm_logic = algorithm)
 }
 \arguments{
 \item{criteria}{The name of the inclusion or exclusion criteria to use.}

--- a/man/include_gld_purchases.Rd
+++ b/man/include_gld_purchases.Rd
@@ -4,7 +4,10 @@
 \alias{include_gld_purchases}
 \title{Include only those who have a purchase of a glucose lowering drug (GLD).}
 \usage{
-include_gld_purchases(data)
+include_gld_purchases(lmdb)
+}
+\arguments{
+\item{lmdb}{The LMDB register.}
 }
 \value{
 The same type as the input data, default as a \code{\link[tibble:tibble]{tibble::tibble()}}.

--- a/vignettes/data-sources.Rmd
+++ b/vignettes/data-sources.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
   comment = "#>"
 )
 library(osdc)
-library(tidyverse)
+library(dplyr)
 ```
 
 This document describes the sources of data needed by the OSDC algorithm


### PR DESCRIPTION
This PR fixes the error and warnings thrown by the `R-CMD-check` workflow. 

This includes: 
- Changing `tidyverse` to `dplyr` in `data-sources.Rmd`
- Adding the missing `@param` `lmdb` for `include_gld_purchases()`
- Running `devtools::check()` that also updates the documentation (`.Rda` files). 