### PR TITLE
ci: :construction_worker: split into main vs PR build CI workflows

### DIFF
--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -1,18 +1,32 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  push:
+  pull_request:
     branches: main
-  release:
-    types: [published]
 
 name: Build package
 
 permissions: read-all
 
 jobs:
+  style:
+    uses: ./.github/workflows/reusable-style.yaml
+    permissions:
+      contents: write
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  document:
+    uses: ./.github/workflows/reusable-document.yaml
+    needs: style
+    permissions:
+      contents: write
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
   cran-check:
     uses: ./.github/workflows/reusable-cran-check.yaml
+    needs: document
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description

These changes are made because the styling and documenting can only be done on non-main branches. So this adds two builds.




