### PR TITLE
ci: :construction_worker: don't need to install all package dependencies for styler

### DIFF
--- a/.github/workflows/reusable-document.yaml
+++ b/.github/workflows/reusable-document.yaml
@@ -40,6 +40,5 @@ jobs:
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git add man/\* NAMESPACE DESCRIPTION
-          git commit -m "Update documentation" || echo "No changes to commit"
-          git pull --ff-only
-          git push origin
+          git commit -m "chore: :bento: Re-generated roxygen2 documentation" || echo "No changes to commit"
+          git push

--- a/.github/workflows/reusable-document.yaml
+++ b/.github/workflows/reusable-document.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.head_ref }}
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/reusable-style.yaml
+++ b/.github/workflows/reusable-style.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.head_ref }}
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/reusable-style.yaml
+++ b/.github/workflows/reusable-style.yaml
@@ -25,11 +25,9 @@ jobs:
         with:
           use-public-rspm: true
 
-      - name: Install dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::styler, any::roxygen2
-          needs: styler
+      - name: Install styler and roxygen2
+        run: install.packages(c("styler", "roxygen2"))
+        shell: Rscript {0}
 
       - name: Enable styler cache
         run: styler::cache_activate()

--- a/.github/workflows/reusable-style.yaml
+++ b/.github/workflows/reusable-style.yaml
@@ -68,9 +68,8 @@ jobs:
           then
             git config --local user.name "$GITHUB_ACTOR"
             git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-            git commit ${FILES_TO_COMMIT[*]} -m "Style code (GHA)"
-            git pull --ff-only
-            git push origin
+            git commit ${FILES_TO_COMMIT[*]} -m "style: :art: Auto-format code with styler"
+            git push
           else
             echo "No changes to commit."
           fi


### PR DESCRIPTION
## Description

These changes are to fix the CI build that is failing to not find the branch to be able to push from. Plus fixed the commit messages to be conventional commit

