### PR TITLE
test: :white_check_mark: replace outdated function for duckdb

### DIFF
--- a/tests/testthat/test-columns-to-lower.R
+++ b/tests/testthat/test-columns-to-lower.R
@@ -17,7 +17,7 @@ test_that("columns are correctly converted to lowercase", {
 test_that("columns are converted for DuckDB Database", {
   skip_on_cran()
   skip_if_not_installed("duckplyr")
-  actual <- duckplyr::as_duckplyr_tibble(data) |>
+  actual <- duckplyr::as_duckdb_tibble(data) |>
     column_names_to_lower() |>
     # DuckDB needs to use `colnames()`
     colnames()

--- a/tests/testthat/test-include-gld-purchases.R
+++ b/tests/testthat/test-include-gld-purchases.R
@@ -55,7 +55,7 @@ test_that("casing of input variables doesn't matter", {
 test_that("verification works for DuckDB Database", {
   skip_on_cran()
   skip_if_not_installed("duckplyr")
-  actual <- duckplyr::as_duckplyr_tibble(lmdb) |>
+  actual <- duckplyr::as_duckdb_tibble(lmdb) |>
     include_gld_purchases()
 
   actual_rows <- actual |>

--- a/tests/testthat/test-include-hba1c.R
+++ b/tests/testthat/test-include-hba1c.R
@@ -60,7 +60,7 @@ test_that("casing of input variables doesn't matter", {
 test_that("verification works for DuckDB Database", {
   skip_on_cran()
   skip_if_not_installed("duckplyr")
-  actual <- duckplyr::as_duckplyr_tibble(lab_forsker) |>
+  actual <- duckplyr::as_duckdb_tibble(lab_forsker) |>
     include_hba1c()
 
   actual_rows <- actual |>

--- a/tests/testthat/test-include-podiatrist-services.R
+++ b/tests/testthat/test-include-podiatrist-services.R
@@ -52,8 +52,8 @@ test_that("verification works for DuckDB Database", {
   skip_on_cran()
   skip_if_not_installed("duckplyr")
 
-  sysi <- duckplyr::as_duckplyr_tibble(sysi)
-  sssy <- duckplyr::as_duckplyr_tibble(sssy)
+  sysi <- duckplyr::as_duckdb_tibble(sysi)
+  sssy <- duckplyr::as_duckdb_tibble(sssy)
   actual <- include_podiatrist_services(sysi, sssy)
 
   actual_rows <- actual |>

--- a/tests/testthat/test-joins.R
+++ b/tests/testthat/test-joins.R
@@ -41,8 +41,8 @@ test_that("lpr_adm and lpr_diag must be in correct arg position", {
 test_that("joining works for DuckDB Database", {
   skip_on_cran()
   skip_if_not_installed("duckplyr")
-  adm_as_duckdb <- duckplyr::as_duckplyr_tibble(actual_lpr_adm)
-  diag_as_duckdb <- duckplyr::as_duckplyr_tibble(actual_lpr_diag)
+  adm_as_duckdb <- duckplyr::as_duckdb_tibble(actual_lpr_adm)
+  diag_as_duckdb <- duckplyr::as_duckdb_tibble(actual_lpr_diag)
   actual <- join_lpr2(
     lpr_adm = adm_as_duckdb,
     lpr_diag = diag_as_duckdb
@@ -150,8 +150,8 @@ test_that("kontakter and diagnoser are in correct order", {
 test_that("joining works for DuckDB Database", {
   skip_on_cran()
   skip_if_not_installed("duckplyr")
-  kontakter_as_duckdb <- duckplyr::as_duckplyr_tibble(actual_kontakter)
-  diagnoser_as_duckdb <- duckplyr::as_duckplyr_tibble(actual_diagnoser)
+  kontakter_as_duckdb <- duckplyr::as_duckdb_tibble(actual_kontakter)
+  diagnoser_as_duckdb <- duckplyr::as_duckdb_tibble(actual_diagnoser)
   actual <- join_lpr3(
     kontakter = kontakter_as_duckdb,
     diagnoser = diagnoser_as_duckdb

--- a/tests/testthat/test-verify-variables.R
+++ b/tests/testthat/test-verify-variables.R
@@ -27,7 +27,7 @@ test_that("the required variables are present in the dataset", {
 test_that("verification works for DuckDB Database", {
   skip_on_cran()
   skip_if_not_installed("duckplyr")
-  actual <- duckplyr::as_duckplyr_tibble(bef_complete) |>
+  actual <- duckplyr::as_duckdb_tibble(bef_complete) |>
     verify_required_variables("bef")
 
   expect_true(actual)


### PR DESCRIPTION
## Description

The `as_duckplyr_tibble()` is deprecated, so need to update to `as_duckdb_tibble()`.

Doesn't need a review.

## Checklist

- [x] Ran `just run-all`

