### PR TITLE
style: :art: remove white space from include hba1c tests

### DIFF
--- a/tests/testthat/test-include-hba1c.R
+++ b/tests/testthat/test-include-hba1c.R
@@ -76,7 +76,7 @@ test_that("verification works for Arrow Tables (from Parquet)", {
   skip_on_cran()
   skip_if_not_installed("arrow")
   actual <- arrow::as_arrow_table(lab_forsker) |>
-    include_hba1c() |> 
+    include_hba1c() |>
     dplyr::compute()
 
   actual_rows <- actual |>


### PR DESCRIPTION
## Description

This kept popping up locally when I run `just run-all`

This PR doesn’t need a review.