### PR TITLE
ci: :bug: need to set `--repo` for `gh pr edit`

### DIFF
--- a/.github/workflows/assign-author-to-pr.yaml
+++ b/.github/workflows/assign-author-to-pr.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Assign PR to author
         run: |
-          gh pr edit $PR --add-assignee $AUTHOR
+          gh pr edit $PR --add-assignee $AUTHOR --repo ${{ github.repository }}
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
           PR: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Description

I think they changed the command to require running in a git repo or to use `--repo` if not in one.

No review needed.
