### PR TITLE
fix: :bug: rename pregnancy event variable in algorithm by removing `lpr2_`

### DIFF
--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -55,12 +55,6 @@ algorithm <- function() {
       logic = "c_diag =~ '^(DE11|250)'",
       comments = ""
     ),
-    lpr2_has_pregnancy_event = list(
-      register = "lpr_diag",
-      title = "LPR2 diagnoses codes for pregnancy-related outcomes",
-      logic = "c_diag =~ '^(DO0[0-6]|DO8[0-4]|DZ3[37])'",
-      comments = "These are recorded pregnancy endings like live births and miscarriages."
-    ),
     lpr2_is_endocrinology_department = list(
       register = "lpr_adm",
       title = "LPR2 endocrinology department",
@@ -91,6 +85,12 @@ algorithm <- function() {
       title = "LPR3 diagnoses codes for T2D",
       logic = "diagnosekode =~ '^(DE11)'",
       comments = ""
+    ),
+    has_pregnancy_event = list(
+      register = "lpr_diag",
+      title = "LPR2 diagnoses codes for pregnancy-related outcomes",
+      logic = "c_diag =~ '^(DO0[0-6]|DO8[0-4]|DZ3[37])'",
+      comments = "These are recorded pregnancy endings like live births and miscarriages."
     ),
     no_pregnancy = list(
       register = NA,


### PR DESCRIPTION
## Description

Since this variable includes both ICD-8 and ICD-10 codes this should cover both LPR2 and LPR3 events.

Please correct me if I'm wrong, @Aastedet :) 

Closes #235 

## Checklist

- [X] Ran `just run-all`
