### PR TITLE
build: :wrench: don't format tribble code [skip ci]

### DIFF
--- a/air.toml
+++ b/air.toml
@@ -6,4 +6,4 @@ line-ending = "auto"
 persistent-line-breaks = true
 exclude = []
 default-exclude = true
-skip = []
+skip = ["tribble"]


### PR DESCRIPTION
## Description

Tribbles are special in the way they are written, so they shouldn't be formatted.

No review needed.
