### PR TITLE
build: :bug: fix notes from CRAN check and sort imports

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^vignettes/articles$
 ^doc$
 ^Meta$
+^air.toml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,20 +35,19 @@ Imports:
     rvest,
     stats,
     tidyr,
-    tidyselect,
-    utils
+    tidyselect
 Suggests:
+    arrow,
+    data.table,
     dbplyr,
+    duckplyr,
     glue,
     knitr,
     rmarkdown,
     spelling,
     stringr,
     testthat (>= 3.0.0),
-    tibble,
-    data.table,
-    arrow,
-    duckplyr
+    tibble
 VignetteBuilder: 
     knitr
 Config/testthat/edition: 3


### PR DESCRIPTION
## Description

There were some notes in the CRAN check that this PR fixes. Plus, I ran `use_tidy_description()` to sort the imports in `DESCRIPTION`.

No need for a review.

## Checklist

- [x] Ran `just run-all`