### PR TITLE
feat: :sparkles: uncomment first exclusion step

### DIFF
--- a/R/classify-diabetes.R
+++ b/R/classify-diabetes.R
@@ -102,8 +102,9 @@ classify_diabetes <- function(
   )
 
   # Exclusion steps -----
-  # gld_hba1c_after_exclusions <- gld_purchases |>
-  #   exclude_potential_pcos(bef = bef) |>
+  gld_hba1c_after_exclusions <- gld_purchases |>
+    exclude_potential_pcos(bef = bef)
+  #   |>
   #   exclude_pregnancy(
   #     # TODO: Need to think about arg naming here..
   #     included_hba1c = hba1c_over_threshold,

--- a/R/exclude-potential-pcos.R
+++ b/R/exclude-potential-pcos.R
@@ -33,6 +33,10 @@ exclude_potential_pcos <- function(gld_purchases, bef) {
   # Use the algorithm criteria to exclude potential PCOS
   column_names_to_lower(gld_purchases) |>
     dplyr::inner_join(column_names_to_lower(bef), by = dplyr::join_by("pnr")) |>
+    dplyr::mutate(
+      date = lubridate::as_date(.data$date),
+      foed_dato = lubridate::as_date(.data$foed_dato)
+    ) |>
     # Use !! to inject the expression into filter
     dplyr::filter(!!criteria) |>
     # Keep only the columns we need


### PR DESCRIPTION
## Description

After I uncommented the first exclusion step, there was an error because the data for date is a string in the form YYYYMMDD. While we said to assume it is a date, if we also assume the variable is in the original format, it won't be a date. So this addition ensures the values are dates.

Closes #218 by not doing what is described in the issue.

## Checklist

- [x] Ran `just run-all`
