### PR TITLE
refactor: :recycle: rename `cpr` column to `pnr` in `join_lpr3()`

### DIFF
--- a/R/joins.R
+++ b/R/joins.R
@@ -23,6 +23,9 @@ join_lpr2 <- function(lpr_adm, lpr_diag) {
 
 #' Join together the LPR3 (`diagnoser` and `kontakter`) registers.
 #'
+#' To prepare the LPR3 data for the inclusion process, this function also
+#' renames the `cpr` variable to `pnr` to match the other registers.
+#'
 #' @param diagnoser The diagnosis register.
 #' @param kontakter The contacts register.
 #'
@@ -41,6 +44,8 @@ join_lpr2 <- function(lpr_adm, lpr_diag) {
 join_lpr3 <- function(kontakter, diagnoser) {
   verify_required_variables(kontakter, "kontakter")
   verify_required_variables(diagnoser, "diagnoser")
+
+  kontakter <- kontakter |> dplyr::rename(pnr = cpr)
 
   dplyr::inner_join(
     column_names_to_lower(kontakter),

--- a/tests/testthat/test-joins.R
+++ b/tests/testthat/test-joins.R
@@ -133,7 +133,7 @@ actual_kontakter <- tibble::tibble(
 )
 
 expected_lpr3 <- tibble::tibble(
-  cpr = c(1, 1, 2),
+  pnr = c(1, 1, 2),
   dw_ek_kontakt = 2:4,
   dato_start = c("20230101", "20220101", "20200101"),
   hovedspeciale_ans = c("Neurologi", "Akut medicin", "Kardiologi"),


### PR DESCRIPTION
## Description

To prepare the register to be joined with other registers.

## Checklist

- [ ] Ran `just run-all`
