### PR TITLE
build: :heavy_minus_sign: move heavier dependencies into 'local-only' install

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,10 +37,6 @@ Imports:
     tidyr,
     tidyselect
 Suggests:
-    arrow,
-    data.table,
-    dbplyr,
-    duckplyr,
     glue,
     knitr,
     rmarkdown,
@@ -51,6 +47,11 @@ Suggests:
 VignetteBuilder: 
     knitr
 Config/testthat/edition: 3
+Config/Needs/local:
+    arrow,
+    data.table,
+    dbplyr,
+    duckplyr
 Encoding: UTF-8
 Language: en-US
 LazyData: true

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install all dependencies **for development only**, like simulating
 more data or running the full test suite, use:
 
 ``` r
-pak::pak("steno-aarhus/osdc")
+pak::pak("steno-aarhus/osdc", dependencies = c("all", "Config/Needs/local"))
 ```
 
 ## Development

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
     just --list --unsorted
 
 # Run all recipes
-run-all: clean install-package-dependencies document update-wordlist spell-check style test build-website check install-package
+run-all: clean install-package-dependencies document spell-check style test build-website check install-package
 
 # Clean up auto-generated files
 clean:
@@ -15,7 +15,8 @@ install-package-dependencies:
   #!/usr/bin/env Rscript
   pak::pak(
     dependencies = c(
-      "all"
+      "all",
+      "Config/Needs/local"
     ),
     ask = FALSE
   )


### PR DESCRIPTION
## Description

To speed up the CI build, I've moved the heavier dependencies out into a dependency location only used when we build locally.

## Checklist

- [x] Ran `just run-all`