### PR TITLE
build: :fire: updating the wordlist shouldn't be automatically done

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
     just --list --unsorted
 
 # Run all recipes
-run-all: clean install-package-dependencies document update-wordlist spell-check style test build-website check install-package
+run-all: clean install-package-dependencies document spell-check style test build-website check install-package
 
 # Clean up auto-generated files
 clean:


### PR DESCRIPTION
## Description

Updating the wordlist should be intentional, not done as part of the build pipeline.

## Checklist

- [x] Ran `just run-all`