### PR TITLE
refactor: :recycle: remove verifying from internal functions

### DIFF
--- a/R/exclude-potential-pcos.R
+++ b/R/exclude-potential-pcos.R
@@ -25,7 +25,6 @@
 #' )
 #' }
 exclude_potential_pcos <- function(gld_purchases, bef) {
-  verify_required_variables(bef, "bef")
   criteria <- get_algorithm_logic("no_potential_pcos") |>
     # To convert the string into an R expression
     rlang::parse_expr()

--- a/R/include-gld-purchases.R
+++ b/R/include-gld-purchases.R
@@ -34,7 +34,6 @@
 #' simulate_registers("lmdb", 100)[[1]] |> include_gld_purchases()
 #' }
 include_gld_purchases <- function(lmdb) {
-  verify_required_variables(lmdb, "lmdb")
   criteria <- get_algorithm_logic("gld") |>
     # To convert the string into an R expression.
     rlang::parse_expr()

--- a/R/include-hba1c.R
+++ b/R/include-hba1c.R
@@ -27,7 +27,6 @@
 #' simulate_registers("lab_forsker", 100)[[1]] |> include_hba1c()
 #' }
 include_hba1c <- function(lab_forsker) {
-  verify_required_variables(lab_forsker, "lab_forsker")
   criteria <- get_algorithm_logic("hba1c") |>
     # To convert the string into an R expression.
     rlang::parse_expr()

--- a/R/include-podiatrist-services.R
+++ b/R/include-podiatrist-services.R
@@ -28,8 +28,6 @@
 #' include_podiatrist_services(register_data$sysi, register_data$sssy)
 #' }
 include_podiatrist_services <- function(sysi, sssy) {
-  verify_required_variables(sysi, "sysi")
-  verify_required_variables(sssy, "sssy")
   criteria <- get_algorithm_logic("podiatrist_services") |>
     # To convert the string into an R expression.
     rlang::parse_expr()

--- a/R/joins.R
+++ b/R/joins.R
@@ -12,8 +12,11 @@
 #' join_lpr2(register_data$lpr_adm, register_data$lpr_diag)
 #' }
 join_lpr2 <- function(lpr_adm, lpr_diag) {
+  # These verify that the argument is also used in the right
+  # order.
   verify_required_variables(lpr_adm, "lpr_adm")
   verify_required_variables(lpr_diag, "lpr_diag")
+
   dplyr::inner_join(
     column_names_to_lower(lpr_adm),
     column_names_to_lower(lpr_diag),
@@ -42,6 +45,8 @@ join_lpr2 <- function(lpr_adm, lpr_diag) {
 #' )
 #' }
 join_lpr3 <- function(kontakter, diagnoser) {
+  # These verify that the argument is also used in the right
+  # order.
   verify_required_variables(kontakter, "kontakter")
   verify_required_variables(diagnoser, "diagnoser")
 

--- a/R/joins.R
+++ b/R/joins.R
@@ -12,11 +12,6 @@
 #' join_lpr2(register_data$lpr_adm, register_data$lpr_diag)
 #' }
 join_lpr2 <- function(lpr_adm, lpr_diag) {
-  # These verify that the argument is also used in the right
-  # order.
-  verify_required_variables(lpr_adm, "lpr_adm")
-  verify_required_variables(lpr_diag, "lpr_diag")
-
   dplyr::inner_join(
     column_names_to_lower(lpr_adm),
     column_names_to_lower(lpr_diag),
@@ -45,11 +40,6 @@ join_lpr2 <- function(lpr_adm, lpr_diag) {
 #' )
 #' }
 join_lpr3 <- function(kontakter, diagnoser) {
-  # These verify that the argument is also used in the right
-  # order.
-  verify_required_variables(kontakter, "kontakter")
-  verify_required_variables(diagnoser, "diagnoser")
-
   kontakter <- kontakter |>
     dplyr::rename("pnr" = "cpr")
 

--- a/tests/testthat/test-joins.R
+++ b/tests/testthat/test-joins.R
@@ -34,19 +34,13 @@ expected_lpr2 <- tibble::tibble(
 
 test_that("joining LPR2 correctly", {
   actual <- join_lpr2(
-    actual_lpr_adm,
-    actual_lpr_diag
+    lpr_adm = actual_lpr_adm,
+    lpr_diag = actual_lpr_diag
   )
 
   expect_equal(actual, expected_lpr2)
 })
 
-test_that("lpr_adm and lpr_diag must be in correct arg position", {
-  expect_error(join_lpr2(
-    actual_lpr_diag,
-    actual_lpr_adm
-  ))
-})
 
 # join_lpr3 -----------------------------------------------------------------
 
@@ -76,16 +70,9 @@ expected_lpr3 <- tibble::tibble(
 
 test_that("joining LPR3 correctly", {
   actual <- join_lpr3(
-    actual_kontakter,
-    actual_diagnoser
+    kontakter = actual_kontakter,
+    diagnoser = actual_diagnoser
   )
 
   expect_equal(actual, expected_lpr3)
-})
-
-test_that("kontakter and diagnoser are in correct order", {
-  expect_error(join_lpr3(
-    actual_diagnoser,
-    actual_kontakter
-  ))
 })


### PR DESCRIPTION
## Description

Since all our functions are internal to `classify_diabetes()`, which runs all the verifying there, we don't need to have the verifying in the internal ones.

## Checklist

- [x] Ran `just run-all`