### PR TITLE
fix(algorithm): :bug: `barnmak` logic in `podiatrist_services`

### DIFF
--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -114,7 +114,7 @@ algorithm <- function() {
       register = NA,
       title = "Podiatrist services",
       logic = "speciale =~ '^54' AND barnmak == 0",
-      comments = "`barnmak` means the services were provided to a child of the individual. When barnmak == 0, the PNR belongs to the recipient of the service. When barnmak == 1, the PNR belongs to the child of the individual."
+      comments = "When `barnmak == 0`, the PNR belongs to the recipient of the service. When `barnmak == 1`, the PNR belongs to the child of the individual."
     ),
     is_not_metformin_for_pcos = list(
       register = NA,

--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -113,9 +113,8 @@ algorithm <- function() {
     podiatrist_services = list(
       register = NA,
       title = "Podiatrist services",
-      logic = "speciale =~ '^54' AND barnmak != 0",
-      # TODO: Explain what barnmark 0 means
-      comments = "`barnmak` means the services were provided to a child of the individual."
+      logic = "speciale =~ '^54' AND barnmak == 0",
+      comments = "`barnmak` means the services were provided to a child of the individual. When barnmak == 0, the PNR belongs to the recipient of the service. When barnmak == 1, the PNR belongs to the child of the individual."
     ),
     no_potential_pcos = list(
       register = NA,

--- a/tests/testthat/test-include-podiatrist-services.R
+++ b/tests/testthat/test-include-podiatrist-services.R
@@ -1,6 +1,6 @@
 sysi <- tibble::tribble(
   ~pnr, ~barnmak, ~speciale, ~honuge,
-  1000000000, 1, 54711, "1879", # removed since barnmark = 0
+  1000000000, 1, 54711, "1879", # removed since barnmark = 1
   2000000000, 0, 54800, "9207", # kept but deduplicated
   2000000000, 0, 54800, "9207", # kept but deduplicated
   3000000000, 0, 54005, "0752", # kept bc it's the first date for this person

--- a/tests/testthat/test-include-podiatrist-services.R
+++ b/tests/testthat/test-include-podiatrist-services.R
@@ -11,7 +11,7 @@ sysi <- tibble::tribble(
 sssy <- tibble::tribble(
   ~pnr, ~barnmak, ~speciale, ~honuge,
   2000000000, 0, 54800, "9207", # kept but deduplicated
-  3000000000, 1, 10000, "1801", # removed since barnmark = 0
+  3000000000, 1, 10000, "1801", # removed since barnmark = 1
   3000000000, 0, 54005, "0830", # kept bc it's the second date for this person
   4000000000, 0, 76255, "1123", # removed since speciale doesn't start with 54
 )

--- a/tests/testthat/test-include-podiatrist-services.R
+++ b/tests/testthat/test-include-podiatrist-services.R
@@ -1,19 +1,19 @@
 sysi <- tibble::tribble(
   ~pnr, ~barnmak, ~speciale, ~honuge,
-  1000000000, 0, 54711, "1879", # removed since barnmark = 0
-  2000000000, 1, 54800, "9207", # kept but deduplicated
-  2000000000, 1, 54800, "9207", # kept but deduplicated
-  3000000000, 1, 54005, "0752", # kept bc it's the first date for this person
-  3000000000, 1, 54005, "2430", # removed bc it's the third date for this person
-  4000000000, 1, 55000, "0044" # removed since speciale doesn't start with 54
+  1000000000, 1, 54711, "1879", # removed since barnmark = 0
+  2000000000, 0, 54800, "9207", # kept but deduplicated
+  2000000000, 0, 54800, "9207", # kept but deduplicated
+  3000000000, 0, 54005, "0752", # kept bc it's the first date for this person
+  3000000000, 0, 54005, "2430", # removed bc it's the third date for this person
+  4000000000, 0, 55000, "0044" # removed since speciale doesn't start with 54
 )
 
 sssy <- tibble::tribble(
   ~pnr, ~barnmak, ~speciale, ~honuge,
-  2000000000, 1, 54800, "9207", # kept but deduplicated
-  3000000000, 0, 10000, "1801", # removed since barnmark = 0
-  3000000000, 1, 54005, "0830", # kept bc it's the second date for this person
-  4000000000, 1, 76255, "1123", # removed since speciale doesn't start with 54
+  2000000000, 0, 54800, "9207", # kept but deduplicated
+  3000000000, 1, 10000, "1801", # removed since barnmark = 0
+  3000000000, 0, 54005, "0830", # kept bc it's the second date for this person
+  4000000000, 0, 76255, "1123", # removed since speciale doesn't start with 54
 )
 
 expected <- tibble::tribble(


### PR DESCRIPTION
## Description

@Aastedet and I had a chat about what `barnmak` actually means when it's 0 and 1, respectively. We found out the the logic needed to be swapped. See the meaning of the value in the `comments` in `algorithm.R`

## Checklist

- [X] Ran `just run-all`
