### PR TITLE
docs: :memo: add `prepare_` to naming conventions

### DIFF
--- a/vignettes/articles/design.Rmd
+++ b/vignettes/articles/design.Rmd
@@ -103,8 +103,10 @@ rules.
     `drop_` or `keep_` (e.g., "first visit date to maternal care for
     pregnancy after 40 weeks"). These types of helpers likely are
     contained in the `get_` functions.
--   Helpers that join registers or output of other functions are
+-   Helpers that join the output of other functions are
     prefixed with `join_`.
+-   Functions that prepare and process register data are prefixed with
+    `prepare_`.
 
 ### Input
 

--- a/vignettes/articles/design.Rmd
+++ b/vignettes/articles/design.Rmd
@@ -103,8 +103,8 @@ rules.
     `drop_` or `keep_` (e.g., "first visit date to maternal care for
     pregnancy after 40 weeks"). These types of helpers likely are
     contained in the `get_` functions.
--   Helpers that join the output of other functions are
-    prefixed with `join_`.
+-   Helpers that join the output of other functions are prefixed with
+    `join_`.
 -   Functions that prepare and process register data are prefixed with
     `prepare_`.
 


### PR DESCRIPTION
## Description

Closes #274 

## Checklist

- [X] Ran `just run-all`
- [X] If docs were added, Markdown is formatted
