### PR TITLE
refactor: :recycle: move lpr2 primary dx logic to algorithm

### DIFF
--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -79,6 +79,12 @@ algorithm <- function() {
       logic = "c_diag =~ '^(DO0[0-6]|DO8[0-4]|DZ3[37])'",
       comments = "These are recorded pregnancy endings like live births and miscarriages."
     ),
+    lpr2_is_primary_dx = list(
+      register = "lpr_diag",
+      title = "LPR2 primary diagnosis",
+      logic = "c_diagtype == 'A'",
+      comments = ""
+    ),
     lpr3_is_endocrinology_dept = list(
       register = "kontakter",
       title = "LPR3 endocrinology department",

--- a/R/prepare-lpr.R
+++ b/R/prepare-lpr.R
@@ -42,7 +42,8 @@ prepare_lpr2 <- function(lpr_adm, lpr_diag) {
     "lpr2_is_t2d_code",
     "lpr2_is_diabetes_code",
     "lpr2_is_endocrinology_dept",
-    "lpr2_is_medical_dept"
+    "lpr2_is_medical_dept",
+    "lpr2_is_primary_dx"
   ) |>
     rlang::set_names() |>
     purrr::map(get_algorithm_logic) |>
@@ -60,7 +61,7 @@ prepare_lpr2 <- function(lpr_adm, lpr_diag) {
       # Algorithm needs c_spec to be an integer to work correctly.
       c_spec = as.integer(.data$c_spec),
       date = lubridate::as_date(.data$d_inddto),
-      is_primary_dx = .data$c_diagtype == "A",
+      is_primary_dx = !!logic$lpr2_is_primary_dx,
       is_diabetes_code = !!logic$lpr2_is_diabetes_code,
       is_t1d_code = !!logic$lpr2_is_t1d_code,
       is_t2d_code = !!logic$lpr2_is_t2d_code,


### PR DESCRIPTION
## Description

This way it's aligned with what's done in `prepare_lpr3()` and all logic in these functions is in the algorithm.

I kept them separate (the one for lpr2 and lpr3) bc the column name differs.

## Checklist

- [X] Ran `just run-all`
