### PR TITLE
docs: :memo: update tables in algorithm vignette

### DIFF
--- a/vignettes/algorithm.Rmd
+++ b/vignettes/algorithm.Rmd
@@ -19,7 +19,7 @@ library(osdc)
 library(dplyr)
 ```
 
-```{r, get algorithm and transform to df, include=FALSE}
+```{r, include=FALSE}
 algorithm_df <- tibble(name = names(algorithm()), value = algorithm()) |>
   tidyr::unnest_wider(value) |>
   dplyr::select(register, name, title, logic, comments)


### PR DESCRIPTION
## Description

In this PR, I transform everything in the algorithm to a df, including the variable name of the logic.

I've kept one table per register, but removed the register column to give more space for the new `name` column and the comments.  

I've added a table at the bottom for all logic with `is.na(register)` to include logic that goes across registers.

Closes #285 

## Checklist

- [X] Ran `just run-all`
