### PR TITLE
style: :art: remove explicit return in `check_required_variables()`

### DIFF
--- a/R/check-required-variables.R
+++ b/R/check-required-variables.R
@@ -43,5 +43,5 @@ check_required_variables <- function(
       call = call
     )
   }
-  return(invisible(TRUE))
+  invisible(TRUE)
 }


### PR DESCRIPTION
## Description

To follow the Tidyverse style, as mentioned in #304 


## Checklist

- [X] Ran `just run-all`

