### PR TITLE
refactor: :fire: `is_non_insulin_gld_code` isn't used, so removing it

### DIFF
--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -35,12 +35,6 @@ algorithm <- function() {
       logic = "atc =~ '^A10' AND NOT (atc =~ '^(A10BJ|A10BK01|A10BK03)')",
       comments = "GLP-RAs or dapagliflozin/empagliflozin drugs are not kept."
     ),
-    is_non_insulin_gld_code = list(
-      register = "lmdb",
-      title = "Non-insulin glucose-lowering drugs",
-      logic = "atc =~ '^A10B' OR atc =~ '^A10AE56'",
-      comments = "This is used during the classification of type 1 diabetes to identify persons who only purchase insulin or mostly purchase insulin."
-    ),
     is_insulin_gld_code = list(
       register = "lmdb",
       title = "Only insulin glucose-lowering drugs",

--- a/R/include-gld-purchases.R
+++ b/R/include-gld-purchases.R
@@ -27,8 +27,6 @@
 #'       for later functions.
 #'   -   `is_insulin_gld_code`: A logical variable to use as a helper indicator
 #'       for later functions, used for classifying type 1 diabetes.
-#'   -   `is_non_insulin_gld_code`: A logical variable to use as a helper
-#'       indicator for later functions, used for classifying type 1 diabetes.
 #'
 #' @keywords internal
 #' @inherit algorithm seealso
@@ -39,7 +37,6 @@
 #' }
 include_gld_purchases <- function(lmdb) {
   logic <- c(
-    "is_non_insulin_gld_code",
     "is_insulin_gld_code",
     "is_gld_code"
   ) |>
@@ -58,7 +55,6 @@ include_gld_purchases <- function(lmdb) {
       # An indicator variable for later joins
       has_gld_purchases = TRUE,
       is_insulin_gld_code = !!logic$is_insulin_gld_code,
-      is_non_insulin_gld_code = !!logic$is_non_insulin_gld_code
     ) |>
     # Keep only the columns we need.
     dplyr::select(
@@ -69,7 +65,6 @@ include_gld_purchases <- function(lmdb) {
       "contained_doses",
       "has_gld_purchases",
       indication_code = "indo",
-      "is_insulin_gld_code",
-      "is_non_insulin_gld_code"
+      "is_insulin_gld_code"
     )
 }

--- a/man/include_gld_purchases.Rd
+++ b/man/include_gld_purchases.Rd
@@ -25,8 +25,6 @@ from \code{indo}).
 for later functions.
 \item \code{is_insulin_gld_code}: A logical variable to use as a helper indicator
 for later functions, used for classifying type 1 diabetes.
-\item \code{is_non_insulin_gld_code}: A logical variable to use as a helper
-indicator for later functions, used for classifying type 1 diabetes.
 }
 }
 \description{

--- a/tests/testthat/test-include-gld-purchases.R
+++ b/tests/testthat/test-include-gld-purchases.R
@@ -21,15 +21,15 @@ lmdb <- tibble::tribble(
   dplyr::bind_cols(constants)
 
 expected <- tibble::tribble(
-  ~atc, ~is_insulin_gld_code, ~is_non_insulin_gld_code,
-  "A10A23", TRUE, FALSE,
-  "A10", FALSE, FALSE,
+  ~atc, ~is_insulin_gld_code,
+  "A10A23", TRUE,
+  "A10", FALSE,
   # This ATC doesn't exist, but is added to be certain
   # the function correctly identifies the drug classes.
-  "A10C", FALSE, FALSE,
-  "A10B", FALSE, TRUE,
-  "A10AE56", FALSE, TRUE,
-  "A10B02", FALSE, TRUE
+  "A10C", FALSE,
+  "A10B", FALSE,
+  "A10AE56", FALSE,
+  "A10B02", FALSE
 ) |>
   dplyr::bind_cols(constants) |>
   dplyr::rename(date = eksd, indication_code = indo) |>
@@ -45,8 +45,7 @@ expected <- tibble::tribble(
     contained_doses,
     has_gld_purchases,
     indication_code,
-    is_insulin_gld_code,
-    is_non_insulin_gld_code
+    is_insulin_gld_code
   )
 
 test_that("dataset needs expected variables", {


### PR DESCRIPTION
## Description

@Aastedet noticed we don't use it in #296, and I checked, and we don't use it anywhere. So this removes it.

Closes #321

## Checklist

- [x] Ran `just run-all`
