### PR TITLE
test: :white_check_mark: simplify tests so most logic is in `classify_diabetes()`

### DIFF
--- a/tests/testthat/test-classify-diabetes.R
+++ b/tests/testthat/test-classify-diabetes.R
@@ -1,3 +1,255 @@
+# Moved from `include_diabetes_diagnoses()` -------------------------------
+
+# test_input_from_lpr2 <- tibble::tribble(
+#   ~pnr, ~date, ~is_primary_dx, ~is_diabetes_code, ~is_t1d_code, ~is_t2d_code,
+#   ~is_pregnancy_code, ~is_endocrinology_dept, ~is_medical_dept,
+
+#   # 00001 - clear T1D case onset in 2015: lpr2: 2x T1D from endo (+ 1 from lpr3)
+#   "00001", "2015-01-01", TRUE, TRUE, TRUE, FALSE, FALSE, TRUE, FALSE,
+#   "00001", "2015-02-01", TRUE, TRUE, TRUE, FALSE, FALSE, TRUE, FALSE,
+
+#   # 00002 - T2D case onset in 2021: 2x non-DM from lpr2, mix of medical dept/other, mostly non-primary
+#   "00002", "2015-01-10", TRUE, TRUE, FALSE, TRUE, FALSE, FALSE, TRUE,
+#   "00002", "2015-01-20", FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,
+#   "00002", "2015-01-30", FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,
+
+#   # 00003 - Non-case: Only a pregnancy record in LPR2, nothing in LPR3
+#   "00003", "2015-06-15", TRUE, FALSE, FALSE, FALSE, TRUE, FALSE, TRUE,
+
+#   # 00004 - T2D case in 2021: Nothing from LPR2, mixed T1D/T2D diags from LPR3, but no primary T1D/T2D diags
+
+#   # 00005 - A non-included case (of likely T1D in LPR3, only non-DM in LPR2)
+#   "00005", "2015-01-01", FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,
+
+#   # 00006 - Equal counts case: 1 x T2D + 1 x T1D from endo from LPR2, same from medical in LPR3
+#   "00006", "2015-02-01", TRUE, TRUE, TRUE, FALSE, FALSE, TRUE, FALSE,
+#   "00006", "2015-03-01", TRUE, TRUE, FALSE, TRUE, FALSE, TRUE, FALSE
+# ) |>
+#   dplyr::mutate(date = as.Date(date))
+
+# test_input_from_lpr3 <- tibble::tribble(
+#   ~pnr, ~date, ~is_primary_dx, ~is_diabetes_code, ~is_t1d_code, ~is_t2d_code,
+#   ~is_pregnancy_code, ~is_endocrinology_dept, ~is_medical_dept,
+
+#   # 00001 - clear T1D case: lpr2: 2x T1D from endo (+ 1 from lpr3)
+#   "00001", "2020-01-01", TRUE, TRUE, TRUE, FALSE, FALSE, TRUE, FALSE,
+
+#   # 00002 - T2D case onset in 2021: 2x non-DM from lpr2, mix of medical dept/other, mostly non-primary
+#   "00002", "2021-01-10", FALSE, TRUE, FALSE, TRUE, FALSE, FALSE, TRUE,
+#   "00002", "2021-01-20", FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,
+#   "00002", "2021-01-30", FALSE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE,
+
+#   # 00003 - Non-case: Only a pregnancy record in LPR2, nothing in LPR3
+
+#   # 00004 - T2D case in 2021: Nothing from LPR2, mixed T1D/T2D diags from LPR3, but no primary T1D/T2D diags
+#   "00004", "2021-07-01", FALSE, TRUE, TRUE, FALSE, FALSE, FALSE, FALSE,
+#   "00004", "2021-07-15", FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE,
+#   "00004", "2021-08-01", TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE,
+#   "00004", "2021-08-15", TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, TRUE,
+
+#   # 00005 - A non-included case (of likely T1D in LPR3, only non-DM diags in LPR2)
+#   "00005", "2022-01-01", TRUE, TRUE, TRUE, FALSE, FALSE, TRUE, FALSE,
+
+#   # 00006 - Equal counts case: 1 x T2D + 1 x T1D from endo from LPR2, same from medical in LPR3
+#   "00006", "2022-02-01", TRUE, TRUE, TRUE, FALSE, FALSE, FALSE, TRUE,
+#   "00006", "2022-03-01", TRUE, TRUE, FALSE, TRUE, FALSE, FALSE, TRUE
+# ) |>
+#   dplyr::mutate(date = as.Date(date))
+
+# expected <- tibble::tribble(
+#   ~pnr, ~date, ~n_t1d_endocrinology, ~n_t2d_endocrinology, ~n_t1d_medical, ~n_t2d_medical,
+#   "00001", "2015-01-01", 3, 0, 0, 0,
+#   "00001", "2015-02-01", 3, 0, 0, 0,
+#   "00002", "2015-01-10", 0, 0, 0, 1,
+#   "00002", "2021-01-10", 0, 0, 0, 1,
+#   "00004", "2021-07-01", 0, 0, 0, 0,
+#   "00004", "2021-08-01", 0, 0, 0, 0,
+#   "00005", "2022-01-01", 1, 0, 0, 0,
+#   "00006", "2015-02-01", 1, 1, 1, 1,
+#   "00006", "2015-03-01", 1, 1, 1, 1
+# ) |>
+#   dplyr::mutate(date = as.Date(date))
+
+# Moved from `exclude-potential-pcos` -------------------------------------
+
+# bef <- tibble::tribble(
+#   ~koen, ~pnr, ~foed_dato,
+#   # Men (as defined by PNR)
+#   1, 1000000001, "1980-01-01",
+#   # Women (as defined by PNR)
+#   2, 2000000000, "1980-01-01",
+#   # No GLD purchases (excluded)
+#   1, 3000000001, "1980-01-01",
+#   2, 4000000000, "1980-01-01",
+# ) |>
+#   dplyr::mutate(
+#     pnr = as.character(pnr),
+#     foed_dato = lubridate::as_date(foed_dato)
+#   )
+
+# gld_purchases <- tibble::tribble(
+#   ~pnr, ~date, ~atc, ~has_gld_purchases, ~indication_code,
+#   # Men (as defined by PNR)
+#   ## ATC matches criteria
+#   ### Age at purchase matches criteria (< 40)
+#   1000000001, "2010-02-02", "A10BA02", TRUE, "324314324",
+#   1000000001, "2010-02-02", "A10BA02", TRUE, "0000092", # indication_code matches
+#   ### Age at purchase doesn't match (= 40)
+#   1000000001, "2020-02-02", "A10BA02", TRUE, "324314324",
+#   1000000001, "2020-02-02", "A10BA02", TRUE, "0000781", # indication_code matches
+#   ### Age at purchase doesn't match (> 40)
+#   1000000001, "2025-02-02", "A10BA02", TRUE, "324314324",
+#   1000000001, "2025-02-02", "A10BA02", TRUE, "0000276", # indication_code matches
+#   ## ATC doesn't match criteria
+#   ### Age at purchase matches criteria (< 40)
+#   1000000001, "2010-02-02", "A10", TRUE, "324314324",
+#   1000000001, "2010-02-02", "A10", TRUE, "0000092", # indication_code matches
+#   ### Age at purchase doesn't match (= 40)
+#   1000000001, "2020-02-02", "A10", TRUE, "324314324",
+#   1000000001, "2020-02-02", "A10", TRUE, "0000781", # indication_code matches
+#   ### Age at purchase doesn't match (> 40)
+#   1000000001, "2025-02-02", "A10", TRUE, "324314324",
+#   1000000001, "2025-02-02", "A10", TRUE, "0000276", # indication_code matches
+
+#   # Women (as defined by PNR)
+#   ## ATC matches criteria
+#   ### Age at purchase matches criteria (< 40)
+#   2000000000, "2010-02-02", "A10BA02", TRUE, "324314324", # excluded
+#   2000000000, "2010-02-02", "A10BA02", TRUE, "0000092", # indication_code matches, excluded
+#   ### Age at purchase doesn't match (= 40)
+#   2000000000, "2020-02-02", "A10BA02", TRUE, "324314324",
+#   2000000000, "2020-02-02", "A10BA02", TRUE, "0000781", # indication_code matches, excluded
+#   ### Age at purchase doesn't match (> 40)
+#   2000000000, "2025-02-02", "A10BA02", TRUE, "324314324",
+#   2000000000, "2025-02-02", "A10BA02", TRUE, "0000276", # indication_code matches, excluded
+#   ## ATC doesn't match criteria
+#   ### Age at purchase matches criteria (< 40)
+#   2000000000, "2010-02-02", "A10", TRUE, "324314324",
+#   2000000000, "2010-02-02", "A10", TRUE, "0000092", # indication_code matches
+#   ### Age at purchase doesn't match (= 40)
+#   2000000000, "2020-02-02", "A10", TRUE, "324314324",
+#   2000000000, "2020-02-02", "A10", TRUE, "0000781", # indication_code matches
+#   ### Age at purchase doesn't match (> 40)
+#   2000000000, "2025-02-02", "A10", TRUE, "324314324",
+#   2000000000, "2025-02-02", "A10", TRUE, "0000276", # indication_code matches
+#   # Not in BEF (excluded)
+#   5000000000, "2010-01-01", "A10", TRUE, "0000276",
+# ) |>
+#   dplyr::mutate(pnr = as.character(pnr), date = lubridate::as_date(date))
+
+# expected <- tibble::tribble(
+#   ~pnr, ~date, ~atc, ~has_gld_purchases, ~indication_code, ~no_pcos,
+#   # Men (as defined by PNR)
+#   ## ATC matches criteria
+#   ### Age at purchase matches criteria (< 40)
+#   1000000001, "2010-02-02", "A10BA02", TRUE, "324314324", TRUE,
+#   1000000001, "2010-02-02", "A10BA02", TRUE, "0000092", TRUE, # indication_code matches
+#   ### Age at purchase doesn't match (= 40)
+#   1000000001, "2020-02-02", "A10BA02", TRUE, "324314324", TRUE,
+#   1000000001, "2020-02-02", "A10BA02", TRUE, "0000781", TRUE, # indication_code matches
+#   ### Age at purchase doesn't match (> 40)
+#   1000000001, "2025-02-02", "A10BA02", TRUE, "324314324", TRUE,
+#   1000000001, "2025-02-02", "A10BA02", TRUE, "0000276", TRUE, # indication_code matches
+#   ## ATC doesn't match criteria
+#   ### Age at purchase matches criteria (< 40)
+#   1000000001, "2010-02-02", "A10", TRUE, "324314324", TRUE,
+#   1000000001, "2010-02-02", "A10", TRUE, "0000092", TRUE, # indication_code matches
+#   ### Age at purchase doesn't match (= 40)
+#   1000000001, "2020-02-02", "A10", TRUE, "324314324", TRUE,
+#   1000000001, "2020-02-02", "A10", TRUE, "0000781", TRUE, # indication_code matches
+#   ### Age at purchase doesn't match (> 40)
+#   1000000001, "2025-02-02", "A10", TRUE, "324314324", TRUE,
+#   1000000001, "2025-02-02", "A10", TRUE, "0000276", TRUE, # indication_code matches
+
+#   # Women (as defined by PNR)
+#   ## ATC matches criteria
+#   ### Age at purchase matches criteria (< 40)
+#   ### Age at purchase doesn't match (= 40)
+#   2000000000, "2020-02-02", "A10BA02", TRUE, "324314324", TRUE,
+#   ### Age at purchase doesn't match (> 40)
+#   2000000000, "2025-02-02", "A10BA02", TRUE, "324314324", TRUE,
+#   ## ATC doesn't match criteria
+#   ### Age at purchase matches criteria (< 40)
+#   2000000000, "2010-02-02", "A10", TRUE, "324314324", TRUE,
+#   2000000000, "2010-02-02", "A10", TRUE, "0000092", TRUE, # indication_code matches
+#   ### Age at purchase doesn't match (= 40)
+#   2000000000, "2020-02-02", "A10", TRUE, "324314324", TRUE,
+#   2000000000, "2020-02-02", "A10", TRUE, "0000781", TRUE, # indication_code matches
+#   ### Age at purchase doesn't match (> 40)
+#   2000000000, "2025-02-02", "A10", TRUE, "324314324", TRUE,
+#   2000000000, "2025-02-02", "A10", TRUE, "0000276", TRUE, # indication_code matches
+# ) |>
+#   dplyr::mutate(pnr = as.character(pnr), date = lubridate::as_date(date))
+
+# Moved from `exclude-pregnancy` ------------------------------------------
+
+# excluded_pcos <- tibble::tribble(
+#   ~pnr, ~date, ~atc, ~has_gld_purchases, ~indication_code, ~no_pcos,
+#   # More than 40 weeks before pregnancy event (keep).
+#   1, "2000-01-01", "A10BA02", TRUE, "324314324", TRUE,
+#   1, "2019-01-01", "A10BA02", TRUE, "324314324", TRUE,
+#   # Exactly 40 weeks before pregnancy event (drop).
+#   1, "2009-04-28", "A10BA02", TRUE, "324314324", TRUE,
+#   1, "2019-04-28", "A10BA02", TRUE, "324314324", TRUE,
+#   # Within pregnancy interval (drop).
+#   1, "2010-02-02", "A10BA02", TRUE, "324314324", TRUE,
+#   1, "2020-02-02", "A10BA02", TRUE, "324314324", TRUE,
+#   # Exactly 12 weeks after pregnancy event (drop).
+#   1, "2010-04-27", "A10BA02", TRUE, "324314324", TRUE,
+#   1, "2020-04-26", "A10BA02", TRUE, "324314324", TRUE, # Not the date same as row above bc 2020 is a gap year.
+#   # More than 12 weeks after pregnancy event (keep).
+#   1, "2015-01-01", "A10BA02", TRUE, "324314324", TRUE,
+#   1, "2025-01-01", "A10BA02", TRUE, "324314324", TRUE,
+#   # No pregnancy event (keep).
+#   2, "2010-02-02", "A10BA02", TRUE, "324314324", TRUE,
+# ) |>
+#   dplyr::mutate(date = lubridate::as_date(date))
+#
+# included_hba1c <- tibble::tribble(
+#   ~pnr, ~date,
+#   # More than 40 weeks before pregnancy event (keep).
+#   1, "2000-01-01",
+#   1, "2000-01-02",
+#   # Exactly 40 weeks before pregnancy event (drop).
+#   1, "2009-04-28",
+#   # Within pregnancy interval (drop).
+#   1, "2010-02-02",
+#   # Exactly 12 weeks after pregnancy event (drop).
+#   1, "2010-04-27",
+#   # More than 12 weeks after pregnancy event (keep).
+#   1, "2015-01-02",
+#   # No pregnancy event (keep).
+#   3, "2010-02-02"
+# ) |>
+#   dplyr::mutate(date = lubridate::as_date(date))
+#
+# pregnancy_dates <- tibble::tribble(
+#   ~pnr, ~pregnancy_event_date, ~has_pregnancy_event,
+#   # Two pregnancy events for the same pnr to ensure that all events within both
+#   # pregnancy intervals are excluded.
+#   1, "2010-02-02", TRUE,
+#   1, "2020-02-02", TRUE,
+#   # Pregnancy event for pnr not in gld_purchases and included_hba1c (drop).
+#   4, "2010-01-01", TRUE,
+# ) |>
+#   dplyr::mutate(pregnancy_event_date = lubridate::as_date(pregnancy_event_date))
+#
+# expected <- tibble::tribble(
+#   ~pnr, ~date, ~has_gld_purchases, ~has_elevated_hba1c, ~no_pregnancy,
+#   # From excluded_pcos.
+#   1, "2000-01-01", TRUE, NA, TRUE, # Same pnr and date as row from hba1c, both kept.
+#   1, "2019-01-01", TRUE, NA, TRUE,
+#   1, "2015-01-01", TRUE, NA, TRUE,
+#   1, "2025-01-01", TRUE, NA, TRUE,
+#   2, "2010-02-02", TRUE, NA, TRUE,
+#   # From included_hba1c.
+#   1, "2000-01-01", NA, NA, TRUE, TRUE, # Same pnr and date as row from excluded_pcos, both kept.
+#   1, "2000-01-02", NA, NA, TRUE, TRUE,
+#   1, "2015-01-02", NA, NA, TRUE, TRUE,
+#   3, "2010-02-02", NA, NA, TRUE, TRUE
+# ) |>
+#   dplyr::mutate(date = lubridate::as_date(date))
+
 register_data <- simulate_registers(
   c(
     "kontakter",

--- a/tests/testthat/test-exclude-potential-pcos.R
+++ b/tests/testthat/test-exclude-potential-pcos.R
@@ -1,119 +1,25 @@
-bef <- tibble::tribble(
-  ~koen, ~pnr, ~foed_dato,
-  # Men (as defined by PNR)
-  1, 1000000001, "1980-01-01",
-  # Women (as defined by PNR)
-  2, 2000000000, "1980-01-01",
-  # No GLD purchases (excluded)
-  1, 3000000001, "1980-01-01",
-  2, 4000000000, "1980-01-01",
-) |>
-  dplyr::mutate(
-    pnr = as.character(pnr),
-    foed_dato = lubridate::as_date(foed_dato)
+bef <- simulate_registers("bef", 1000)[[1]] |>
+  dplyr::add_row(
+    koen = 2,
+    foed_dato = "20000101"
   )
-
-gld_purchases <- tibble::tribble(
-  ~pnr, ~date, ~atc, ~contained_doses, ~indication_code,
-  # Men (as defined by PNR)
-  ## ATC matches criteria
-  ### Age at purchase matches criteria (< 40)
-  1000000001, "2010-02-02", "A10BA02", 1.21, "324314324",
-  1000000001, "2010-02-02", "A10BA02", 1.21, "0000092", # indication_code matches
-  ### Age at purchase doesn't match (= 40)
-  1000000001, "2020-02-02", "A10BA02", 1.21, "324314324",
-  1000000001, "2020-02-02", "A10BA02", 1.21, "0000781", # indication_code matches
-  ### Age at purchase doesn't match (> 40)
-  1000000001, "2025-02-02", "A10BA02", 1.21, "324314324",
-  1000000001, "2025-02-02", "A10BA02", 1.21, "0000276", # indication_code matches
-  ## ATC doesn't match criteria
-  ### Age at purchase matches criteria (< 40)
-  1000000001, "2010-02-02", "A10", 1.21, "324314324",
-  1000000001, "2010-02-02", "A10", 1.21, "0000092", # indication_code matches
-  ### Age at purchase doesn't match (= 40)
-  1000000001, "2020-02-02", "A10", 1.21, "324314324",
-  1000000001, "2020-02-02", "A10", 1.21, "0000781", # indication_code matches
-  ### Age at purchase doesn't match (> 40)
-  1000000001, "2025-02-02", "A10", 1.21, "324314324",
-  1000000001, "2025-02-02", "A10", 1.21, "0000276", # indication_code matches
-
-  # Women (as defined by PNR)
-  ## ATC matches criteria
-  ### Age at purchase matches criteria (< 40)
-  2000000000, "2010-02-02", "A10BA02", 1.21, "324314324", # excluded
-  2000000000, "2010-02-02", "A10BA02", 1.21, "0000092", # indication_code matches, excluded
-  ### Age at purchase doesn't match (= 40)
-  2000000000, "2020-02-02", "A10BA02", 1.21, "324314324",
-  2000000000, "2020-02-02", "A10BA02", 1.21, "0000781", # indication_code matches, excluded
-  ### Age at purchase doesn't match (> 40)
-  2000000000, "2025-02-02", "A10BA02", 1.21, "324314324",
-  2000000000, "2025-02-02", "A10BA02", 1.21, "0000276", # indication_code matches, excluded
-  ## ATC doesn't match criteria
-  ### Age at purchase matches criteria (< 40)
-  2000000000, "2010-02-02", "A10", 1.21, "324314324",
-  2000000000, "2010-02-02", "A10", 1.21, "0000092", # indication_code matches
-  ### Age at purchase doesn't match (= 40)
-  2000000000, "2020-02-02", "A10", 1.21, "324314324",
-  2000000000, "2020-02-02", "A10", 1.21, "0000781", # indication_code matches
-  ### Age at purchase doesn't match (> 40)
-  2000000000, "2025-02-02", "A10", 1.21, "324314324",
-  2000000000, "2025-02-02", "A10", 1.21, "0000276", # indication_code matches
-  # Not in BEF (excluded)
-  5000000000, "2010-01-01", "A10", 1.21, "0000276",
-) |>
-  dplyr::mutate(pnr = as.character(pnr), date = lubridate::as_date(date))
-
-expected <- tibble::tribble(
-  ~pnr, ~date, ~atc, ~contained_doses, ~indication_code, ~no_pcos,
-  # Men (as defined by PNR)
-  ## ATC matches criteria
-  ### Age at purchase matches criteria (< 40)
-  1000000001, "2010-02-02", "A10BA02", 1.21, "324314324", TRUE,
-  1000000001, "2010-02-02", "A10BA02", 1.21, "0000092", TRUE, # indication_code matches
-  ### Age at purchase doesn't match (= 40)
-  1000000001, "2020-02-02", "A10BA02", 1.21, "324314324", TRUE,
-  1000000001, "2020-02-02", "A10BA02", 1.21, "0000781", TRUE, # indication_code matches
-  ### Age at purchase doesn't match (> 40)
-  1000000001, "2025-02-02", "A10BA02", 1.21, "324314324", TRUE,
-  1000000001, "2025-02-02", "A10BA02", 1.21, "0000276", TRUE, # indication_code matches
-  ## ATC doesn't match criteria
-  ### Age at purchase matches criteria (< 40)
-  1000000001, "2010-02-02", "A10", 1.21, "324314324", TRUE,
-  1000000001, "2010-02-02", "A10", 1.21, "0000092", TRUE, # indication_code matches
-  ### Age at purchase doesn't match (= 40)
-  1000000001, "2020-02-02", "A10", 1.21, "324314324", TRUE,
-  1000000001, "2020-02-02", "A10", 1.21, "0000781", TRUE, # indication_code matches
-  ### Age at purchase doesn't match (> 40)
-  1000000001, "2025-02-02", "A10", 1.21, "324314324", TRUE,
-  1000000001, "2025-02-02", "A10", 1.21, "0000276", TRUE, # indication_code matches
-
-  # Women (as defined by PNR)
-  ## ATC matches criteria
-  ### Age at purchase matches criteria (< 40)
-  ### Age at purchase doesn't match (= 40)
-  2000000000, "2020-02-02", "A10BA02", 1.21, "324314324", TRUE,
-  ### Age at purchase doesn't match (> 40)
-  2000000000, "2025-02-02", "A10BA02", 1.21, "324314324", TRUE,
-  ## ATC doesn't match criteria
-  ### Age at purchase matches criteria (< 40)
-  2000000000, "2010-02-02", "A10", 1.21, "324314324", TRUE,
-  2000000000, "2010-02-02", "A10", 1.21, "0000092", TRUE, # indication_code matches
-  ### Age at purchase doesn't match (= 40)
-  2000000000, "2020-02-02", "A10", 1.21, "324314324", TRUE,
-  2000000000, "2020-02-02", "A10", 1.21, "0000781", TRUE, # indication_code matches
-  ### Age at purchase doesn't match (> 40)
-  2000000000, "2025-02-02", "A10", 1.21, "324314324", TRUE,
-  2000000000, "2025-02-02", "A10", 1.21, "0000276", TRUE, # indication_code matches
-) |>
-  dplyr::mutate(pnr = as.character(pnr), date = lubridate::as_date(date))
-
+gld_purchases <- simulate_registers("lmdb", 1000)[[1]] |>
+  include_gld_purchases() |>
+  dplyr::add_row(
+    date = "20200101",
+    atc = "A10BA02",
+    # Not an indication code from the logic, so it doesn't
+    # trigger the `OR` part.
+    indication_code = "0000091",
+  )
 
 test_that("bef needs expected variables", {
   bef <- bef[-2]
   expect_error(exclude_potential_pcos(gld_purchases, bef))
 })
 
-test_that("potential pcos instances are excluded", {
+test_that("at least 1 'case' is removed using the simulated data", {
   actual <- exclude_potential_pcos(gld_purchases, bef)
-  expect_equal(actual, expected)
+  # Should be at least one row less after exclusion.
+  expect_true(nrow(actual) <= nrow(gld_purchases) - 1)
 })

--- a/tests/testthat/test-exclude-pregnancy.R
+++ b/tests/testthat/test-exclude-pregnancy.R
@@ -1,71 +1,37 @@
-excluded_pcos <- tibble::tribble(
-  ~pnr, ~date, ~atc, ~contained_doses, ~indication_code, ~no_pcos,
-  # More than 40 weeks before pregnancy event (keep).
-  1, "2000-01-01", "A10BA02", 1.21, "324314324", TRUE,
-  1, "2019-01-01", "A10BA02", 1.21, "324314324", TRUE,
-  # Exactly 40 weeks before pregnancy event (drop).
-  1, "2009-04-28", "A10BA02", 1.21, "324314324", TRUE,
-  1, "2019-04-28", "A10BA02", 1.21, "324314324", TRUE,
-  # Within pregnancy interval (drop).
-  1, "2010-02-02", "A10BA02", 1.21, "324314324", TRUE,
-  1, "2020-02-02", "A10BA02", 1.21, "324314324", TRUE,
-  # Exactly 12 weeks after pregnancy event (drop).
-  1, "2010-04-27", "A10BA02", 1.21, "324314324", TRUE,
-  1, "2020-04-26", "A10BA02", 1.21, "324314324", TRUE, # Not the date same as row above bc 2020 is a gap year.
-  # More than 12 weeks after pregnancy event (keep).
-  1, "2015-01-01", "A10BA02", 1.21, "324314324", TRUE,
-  1, "2025-01-01", "A10BA02", 1.21, "324314324", TRUE,
-  # No pregnancy event (keep).
-  2, "2010-02-02", "A10BA02", 1.21, "324314324", TRUE,
-) |>
-  dplyr::mutate(date = lubridate::as_date(date))
+register_data <- simulate_registers(
+  c(
+    "lpr_adm",
+    "lpr_diag",
+    "kontakter",
+    "diagnoser",
+    "lmdb",
+    "bef",
+    "lab_forsker"
+  ),
+  n = 1000
+)
+lpr2 <- prepare_lpr2(
+  lpr_adm = register_data$lpr_adm,
+  lpr_diag = register_data$lpr_diag
+)
+lpr3 <- prepare_lpr3(
+  kontakter = register_data$kontakter,
+  diagnoser = register_data$diagnoser
+)
 
-included_hba1c <- tibble::tribble(
-  ~pnr, ~date,
-  # More than 40 weeks before pregnancy event (keep).
-  1, "2000-01-01",
-  1, "2000-01-02",
-  # Exactly 40 weeks before pregnancy event (drop).
-  1, "2009-04-28",
-  # Within pregnancy interval (drop).
-  1, "2010-02-02",
-  # Exactly 12 weeks after pregnancy event (drop).
-  1, "2010-04-27",
-  # More than 12 weeks after pregnancy event (keep).
-  1, "2015-01-02",
-  # No pregnancy event (keep).
-  3, "2010-02-02",
-) |>
-  dplyr::mutate(date = lubridate::as_date(date))
+no_pcos <- register_data$lmdb |>
+  include_gld_purchases() |>
+  exclude_potential_pcos(register_data$bef)
 
-pregnancy_dates <- tibble::tribble(
-  ~pnr, ~pregnancy_event_date, ~has_pregnancy_event,
-  # Two pregnancy events for the same pnr to ensure that all events within both
-  # pregnancy intervals are excluded.
-  1, "2010-02-02", TRUE,
-  1, "2020-02-02", TRUE,
-  # Pregnancy event for pnr not in gld_purchases and included_hba1c (drop).
-  4, "2010-01-01", TRUE,
-) |>
-  dplyr::mutate(pregnancy_event_date = lubridate::as_date(pregnancy_event_date))
+preg_dates <- get_pregnancy_dates(lpr2, lpr3)
 
-expected <- tibble::tribble(
-  ~pnr, ~date, ~contained_doses, ~no_pregnancy,
-  # From excluded_pcos.
-  1, "2000-01-01", 1.21, TRUE, # Same pnr and date as row from hba1c, both kept.
-  1, "2019-01-01", 1.21, TRUE,
-  1, "2015-01-01", 1.21, TRUE,
-  1, "2025-01-01", 1.21, TRUE,
-  2, "2010-02-02", 1.21, TRUE,
-  # From included_hba1c.
-  1, "2000-01-01", NA, TRUE, # Same pnr and date as row from excluded_pcos, both kept.
-  1, "2000-01-02", NA, TRUE,
-  1, "2015-01-02", NA, TRUE,
-  3, "2010-02-02", NA, TRUE
-) |>
-  dplyr::mutate(date = lubridate::as_date(date))
+hba1c <- include_hba1c(register_data$lab_forsker)
 
 test_that("pregnancy events are excluded as expected", {
-  actual <- exclude_pregnancy(excluded_pcos, pregnancy_dates, included_hba1c)
-  expect_equal(actual, expected)
+  actual <- exclude_pregnancy(
+    excluded_pcos = no_pcos,
+    pregnancy_dates = preg_dates,
+    included_hba1c = hba1c
+  )
+  expect_contains(class(actual), "data.frame")
 })

--- a/tests/testthat/test-include-diabetes-diagnoses.R
+++ b/tests/testthat/test-include-diabetes-diagnoses.R
@@ -1,84 +1,26 @@
-test_input_from_lpr2 <- tibble::tribble(
-  ~pnr, ~date, ~is_primary_dx, ~is_diabetes_code, ~is_t1d_code, ~is_t2d_code,
-  ~is_pregnancy_code, ~is_endocrinology_dept, ~is_medical_dept,
+register_data <- simulate_registers(c(
+  "lpr_diag",
+  "lpr_adm",
+  "diagnoser",
+  "kontakter"
+))
 
-  # 00001 - clear T1D case onset in 2015: lpr2: 2x T1D from endo (+ 1 from lpr3)
-  "00001", "2015-01-01", TRUE, TRUE, TRUE, FALSE, FALSE, TRUE, FALSE,
-  "00001", "2015-02-01", TRUE, TRUE, TRUE, FALSE, FALSE, TRUE, FALSE,
+lpr2 <- prepare_lpr2(
+  lpr_adm = register_data$lpr_adm,
+  lpr_diag = register_data$lpr_diag
+)
 
-  # 00002 - T2D case onset in 2021: 2x non-DM from lpr2, mix of medical dept/other, mostly non-primary
-  "00002", "2015-01-10", TRUE, TRUE, FALSE, TRUE, FALSE, FALSE, TRUE,
-  "00002", "2015-01-20", FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,
-  "00002", "2015-01-30", FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,
+lpr3 <- prepare_lpr3(
+  kontakter = register_data$kontakter,
+  diagnoser = register_data$diagnoser
+)
 
-  # 00003 - Non-case: Only a pregnancy record in LPR2, nothing in LPR3
-  "00003", "2015-06-15", TRUE, FALSE, FALSE, FALSE, TRUE, FALSE, TRUE,
 
-  # 00004 - T2D case in 2021: Nothing from LPR2, mixed T1D/T2D diags from LPR3, but no primary T1D/T2D diags
-
-  # 00005 - A non-included case (of likely T1D in LPR3, only non-DM in LPR2)
-  "00005", "2015-01-01", FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,
-
-  # 00006 - Equal counts case: 1 x T2D + 1 x T1D from endo from LPR2, same from medical in LPR3
-  "00006", "2015-02-01", TRUE, TRUE, TRUE, FALSE, FALSE, TRUE, FALSE,
-  "00006", "2015-03-01", TRUE, TRUE, FALSE, TRUE, FALSE, TRUE, FALSE
-) |>
-  dplyr::mutate(date = as.Date(date))
-
-test_input_from_lpr3 <- tibble::tribble(
-  ~pnr, ~date, ~is_primary_dx, ~is_diabetes_code, ~is_t1d_code, ~is_t2d_code,
-  ~is_pregnancy_code, ~is_endocrinology_dept, ~is_medical_dept,
-
-  # 00001 - clear T1D case: lpr2: 2x T1D from endo (+ 1 from lpr3)
-  "00001", "2020-01-01", TRUE, TRUE, TRUE, FALSE, FALSE, TRUE, FALSE,
-
-  # 00002 - T2D case onset in 2021: 2x non-DM from lpr2, mix of medical dept/other, mostly non-primary
-  "00002", "2021-01-10", FALSE, TRUE, FALSE, TRUE, FALSE, FALSE, TRUE,
-  "00002", "2021-01-20", FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,
-  "00002", "2021-01-30", FALSE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE,
-
-  # 00003 - Non-case: Only a pregnancy record in LPR2, nothing in LPR3
-
-  # 00004 - T2D case in 2021: Nothing from LPR2, mixed T1D/T2D diags from LPR3, but no primary T1D/T2D diags
-  "00004", "2021-07-01", FALSE, TRUE, TRUE, FALSE, FALSE, FALSE, FALSE,
-  "00004", "2021-07-15", FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE,
-  "00004", "2021-08-01", TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, FALSE,
-  "00004", "2021-08-15", TRUE, TRUE, FALSE, FALSE, FALSE, FALSE, TRUE,
-
-  # 00005 - A non-included case (of likely T1D in LPR3, only non-DM diags in LPR2)
-  "00005", "2022-01-01", TRUE, TRUE, TRUE, FALSE, FALSE, TRUE, FALSE,
-
-  # 00006 - Equal counts case: 1 x T2D + 1 x T1D from endo from LPR2, same from medical in LPR3
-  "00006", "2022-02-01", TRUE, TRUE, TRUE, FALSE, FALSE, FALSE, TRUE,
-  "00006", "2022-03-01", TRUE, TRUE, FALSE, TRUE, FALSE, FALSE, TRUE
-) |>
-  dplyr::mutate(date = as.Date(date))
-
-expected <- tibble::tribble(
-  ~pnr, ~date, ~n_t1d_endocrinology, ~n_t2d_endocrinology, ~n_t1d_medical, ~n_t2d_medical,
-  "00001", "2015-01-01", 3, 0, 0, 0,
-  "00001", "2015-02-01", 3, 0, 0, 0,
-  "00002", "2015-01-10", 0, 0, 0, 1,
-  "00002", "2021-01-10", 0, 0, 0, 1,
-  "00004", "2021-07-01", 0, 0, 0, 0,
-  "00004", "2021-08-01", 0, 0, 0, 0,
-  "00005", "2022-01-01", 1, 0, 0, 0,
-  "00006", "2015-02-01", 1, 1, 1, 1,
-  "00006", "2015-03-01", 1, 1, 1, 1
-) |>
-  dplyr::mutate(date = as.Date(date))
-
-# Test
-test_that("Filtering and counting diabetes diagnoses", {
+test_that("creates a data.frame output", {
   actual <- include_diabetes_diagnoses(
-    test_input_from_lpr2,
-    test_input_from_lpr3
+    lpr2 = lpr2,
+    lpr3 = lpr3
   )
 
-  # Sorted stable comparison
-  actual_sorted <- dplyr::arrange(actual, pnr, date)
-  expected_sorted <- dplyr::arrange(expected, pnr, date)
-
-  # Test
-  expect_equal(actual_sorted, expected_sorted)
+  expect_contains(class(actual), "data.frame")
 })

--- a/tests/testthat/test-include-gld-purchases.R
+++ b/tests/testthat/test-include-gld-purchases.R
@@ -1,57 +1,11 @@
-constants <- tibble::tibble(
-  pnr = "2132131231",
-  eksd = "20210101",
-  volume = 1.1,
-  apk = 1.1,
-  indo = "324314324"
-)
-
-lmdb <- tibble::tribble(
-  ~atc,
-  "A10A23",
-  "A10",
-  "A10C",
-  "A10B",
-  "A10AE56",
-  "A10B02",
-  "A11",
-  "A21",
-  "B10A10",
-) |>
-  dplyr::bind_cols(constants)
-
-expected <- tibble::tribble(
-  ~atc, ~is_insulin_gld_code,
-  "A10A23", TRUE,
-  "A10", FALSE,
-  # This ATC doesn't exist, but is added to be certain
-  # the function correctly identifies the drug classes.
-  "A10C", FALSE,
-  "A10B", FALSE,
-  "A10AE56", FALSE,
-  "A10B02", FALSE
-) |>
-  dplyr::bind_cols(constants) |>
-  dplyr::rename(date = eksd, indication_code = indo) |>
-  dplyr::mutate(
-    contained_doses = volume * apk
-  ) |>
-  dplyr::select(-volume, -apk) |>
-  dplyr::relocate(
-    pnr,
-    date,
-    atc,
-    contained_doses,
-    indication_code,
-    is_insulin_gld_code
-  )
+lmdb <- simulate_registers("lmdb", 1000)[[1]]
 
 test_that("dataset needs expected variables", {
   actual <- lmdb[-2]
   expect_error(include_gld_purchases(actual))
 })
 
-test_that("those with inclusion are kept", {
+test_that("creates a data.frame output", {
   actual <- include_gld_purchases(lmdb)
-  expect_equal(actual, expected)
+  expect_contains(class(actual), "data.frame")
 })


### PR DESCRIPTION
## Description

To make other PRs smaller. This simplifies the tests and moves the main logic into the `classify_diabetes()` tests (which is where they should be.

## Checklist

- [x] Ran `just run-all`
