### PR TITLE
refactor: ♻️ move `add_insulin_purchases_cols()` down to after exclusions

### DIFF
--- a/R/add.R
+++ b/R/add.R
@@ -49,7 +49,7 @@ add_insulin_purchases_cols <- function(gld_hba1c_after_exclusions) {
     ) |>
     dplyr::summarise(
       # Get first date of a GLD purchase and if a purchase of insulin occurs
-      # within 180 day of the first purchase.
+      # within 180 days of the first purchase.
       first_gld_date = min(date, na.rm = TRUE),
       has_insulin_purchases_within_180_days = any(
         !!logic$has_insulin_purchases_within_180_days

--- a/R/add.R
+++ b/R/add.R
@@ -51,9 +51,7 @@ add_insulin_purchases_cols <- function(gld_hba1c_after_exclusions) {
       # Get first date of a GLD purchase and if a purchase of insulin occurs
       # within 180 days of the first purchase.
       first_gld_date = min(date, na.rm = TRUE),
-      has_insulin_purchases_within_180_days = any(
-        !!logic$has_insulin_purchases_within_180_days
-      ),
+      has_insulin_purchases_within_180_days = !!logic$has_insulin_purchases_within_180_days,
       # Sum up total doses of insulin and of all GLD.
       n_insulin_doses = sum(
         .data$contained_doses[.data$is_insulin_gld_code],

--- a/R/add.R
+++ b/R/add.R
@@ -21,7 +21,7 @@
 #'   include_gld_purchases() |>
 #'   add_insulin_purchases_cols()
 #' }
-add_insulin_purchases_cols <- function(gld_purchases) {
+add_insulin_purchases_cols <- function(gld_hba1c_after_exclusions) {
   logic <- c(
     "is_insulin_gld_code",
     "has_two_thirds_insulin",
@@ -33,7 +33,7 @@ add_insulin_purchases_cols <- function(gld_purchases) {
     # To convert the string into an R expression.
     purrr::map(rlang::parse_expr)
 
-  insulin_cols <- gld_purchases |>
+  insulin_cols <- gld_hba1c_after_exclusions |>
     # `volume` is the doses contained in the purchased package and `apk` is the
     # number of packages purchased
     dplyr::mutate(
@@ -74,6 +74,6 @@ add_insulin_purchases_cols <- function(gld_purchases) {
       "has_insulin_purchases_within_180_days"
     )
 
-  gld_purchases |>
+  gld_hba1c_after_exclusions |>
     dplyr::left_join(insulin_cols, by = dplyr::join_by("pnr"))
 }

--- a/R/add.R
+++ b/R/add.R
@@ -1,6 +1,6 @@
 #' Add columns for information about insulin drug purchases
 #'
-#' @param gld_purchases The data from [include_gld_purchases()] function.
+#' @param gld_hba1c_after_exclusions The GLD and HbA1c data after exclusions
 #'
 #' @return The same type as the input data, default as a [tibble::tibble()].
 #'   Three new columns are added:

--- a/R/add.R
+++ b/R/add.R
@@ -51,7 +51,9 @@ add_insulin_purchases_cols <- function(gld_hba1c_after_exclusions) {
       # Get first date of a GLD purchase and if a purchase of insulin occurs
       # within 180 day of the first purchase.
       first_gld_date = min(date, na.rm = TRUE),
-      has_insulin_purchases_within_180_days = !!logic$has_insulin_purchases_within_180_days,
+      has_insulin_purchases_within_180_days = any(
+        !!logic$has_insulin_purchases_within_180_days
+      ),
       # Sum up total doses of insulin and of all GLD.
       n_insulin_doses = sum(
         .data$contained_doses[.data$is_insulin_gld_code],

--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -171,7 +171,7 @@ algorithm <- function() {
     has_insulin_purchases_within_180_days = list(
       register = NA,
       title = "Whether any insulin was purchased within 180 days of the first purchase of GLD",
-      logic = "ANY (is_insulin_gld_code & date <= (first_gld_date + days(180)))",
+      logic = "any(is_insulin_gld_code & date <= (first_gld_date + days(180)))",
       comments = "This is used to classify type 1 diabetes. It determines if any insulin was bought shortly after first buying any type of GLD, which suggests type 1 diabetes."
     )
   )
@@ -202,7 +202,6 @@ get_algorithm_logic <- function(logic_name, algorithm = NULL) {
     stringr::str_replace_all("AND", "&") |>
     stringr::str_replace_all("OR", "|") |>
     stringr::str_replace_all("NOT", "!") |>
-    stringr::str_replace_all("ANY", "any") |>
     # regex are defined with '=~', so convert them into a stringr function.
     stringr::str_replace_all(
       "([a-zA-Z0-9_]+) \\=\\~ '(.*?)'",

--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -170,9 +170,9 @@ algorithm <- function() {
     ),
     has_insulin_purchases_within_180_days = list(
       register = NA,
-      title = "Whether insulin was purchased within 180 days of the first purchase of GLD",
-      logic = "is_insulin_gld_code & date <= (first_gld_date + days(180))",
-      comments = "This is used to classify type 1 diabetes. It determines if insulin was bought shortly after first buying any type of GLD, which suggests type 1 diabetes."
+      title = "Whether any insulin was purchased within 180 days of the first purchase of GLD",
+      logic = "ANY (is_insulin_gld_code & date <= (first_gld_date + days(180)))",
+      comments = "This is used to classify type 1 diabetes. It determines if any insulin was bought shortly after first buying any type of GLD, which suggests type 1 diabetes."
     )
   )
 }
@@ -202,6 +202,7 @@ get_algorithm_logic <- function(logic_name, algorithm = NULL) {
     stringr::str_replace_all("AND", "&") |>
     stringr::str_replace_all("OR", "|") |>
     stringr::str_replace_all("NOT", "!") |>
+    stringr::str_replace_all("ANY", "any") |>
     # regex are defined with '=~', so convert them into a stringr function.
     stringr::str_replace_all(
       "([a-zA-Z0-9_]+) \\=\\~ '(.*?)'",

--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -170,7 +170,7 @@ algorithm <- function() {
     ),
     has_insulin_purchases_within_180_days = list(
       register = NA,
-      title = "Any insulin purchases within 180 days of the first purchase of GLD",
+      title = "Whether insulin was purchased within 180 days of the first purchase of GLD",
       logic = "is_insulin_gld_code & date <= (first_gld_date + days(180))",
       comments = "This is used to classify type 1 diabetes. It determines if insulin was bought shortly after first buying any type of GLD, which suggests type 1 diabetes."
     )

--- a/R/classify-diabetes.R
+++ b/R/classify-diabetes.R
@@ -117,8 +117,7 @@ classify_diabetes <- function(
 
   gld_purchases <- include_gld_purchases(
     lmdb = lmdb
-  ) |>
-    add_insulin_purchases_cols()
+  )
 
   hba1c_over_threshold <- include_hba1c(
     lab_forsker = lab_forsker
@@ -130,7 +129,8 @@ classify_diabetes <- function(
     exclude_pregnancy(
       pregnancy_dates = pregnancy_dates,
       included_hba1c = hba1c_over_threshold
-    )
+    ) |>
+    add_insulin_purchases_cols()
 
   # Joining into an initial dataset -----
   inclusions <- join_inclusions(

--- a/R/exclude-potential-pcos.R
+++ b/R/exclude-potential-pcos.R
@@ -42,7 +42,5 @@ exclude_potential_pcos <- function(gld_purchases, bef) {
     dplyr::select(
       -"koen",
       -"foed_dato"
-    ) |>
-    # Add logical helper variable
-    dplyr::mutate(no_pcos = TRUE)
+    )
 }

--- a/R/exclude-potential-pcos.R
+++ b/R/exclude-potential-pcos.R
@@ -40,13 +40,8 @@ exclude_potential_pcos <- function(gld_purchases, bef) {
     dplyr::filter(!!logic) |>
     # Keep only the columns we need
     dplyr::select(
-      "pnr",
-      "date",
-      "atc",
-      "indication_code",
-      "has_two_thirds_insulin",
-      "has_only_insulin_purchases",
-      "has_insulin_purchases_within_180_days"
+      -"koen",
+      -"foed_dato"
     ) |>
     # Add logical helper variable
     dplyr::mutate(no_pcos = TRUE)

--- a/R/exclude-pregnancy.R
+++ b/R/exclude-pregnancy.R
@@ -107,7 +107,10 @@ exclude_pregnancy <- function(
     # Select relevant columns.
     dplyr::select(
       "pnr",
-      "date"
+      "date",
+      "volume",
+      "atc",
+      "apk"
     ) |>
     # Remove duplicates after pregnancy date column has been removed.
     # Duplicates are created when a pnr has multiple pregnancy events and a

--- a/R/exclude-pregnancy.R
+++ b/R/exclude-pregnancy.R
@@ -115,7 +115,5 @@ exclude_pregnancy <- function(
     # Remove duplicates after pregnancy date column has been removed.
     # Duplicates are created when a pnr has multiple pregnancy events and a
     # row that falls outside all of them.
-    dplyr::distinct() |>
-    # Add logical helper variable.
-    dplyr::mutate(no_pregnancy = TRUE)
+    dplyr::distinct()
 }

--- a/man/add_insulin_purchases_cols.Rd
+++ b/man/add_insulin_purchases_cols.Rd
@@ -7,7 +7,7 @@
 add_insulin_purchases_cols(gld_hba1c_after_exclusions)
 }
 \arguments{
-\item{gld_hba1c_after_exclusions}{The gld and hba1c data after exclusions}
+\item{gld_hba1c_after_exclusions}{The GLD and HbA1c data after exclusions}
 }
 \value{
 The same type as the input data, default as a \code{\link[tibble:tibble]{tibble::tibble()}}.

--- a/man/add_insulin_purchases_cols.Rd
+++ b/man/add_insulin_purchases_cols.Rd
@@ -4,10 +4,10 @@
 \alias{add_insulin_purchases_cols}
 \title{Add columns for information about insulin drug purchases}
 \usage{
-add_insulin_purchases_cols(gld_purchases)
+add_insulin_purchases_cols(gld_hba1c_after_exclusions)
 }
 \arguments{
-\item{gld_purchases}{The data from \code{\link[=include_gld_purchases]{include_gld_purchases()}} function.}
+\item{gld_hba1c_after_exclusions}{The gld and hba1c data after exclusions}
 }
 \value{
 The same type as the input data, default as a \code{\link[tibble:tibble]{tibble::tibble()}}.


### PR DESCRIPTION
## Description

This PR moved `add_insulin_purchases_cols()` down after exclusions so the columns are based only on the rows we keep (i.e., after removing purchases linked to potential PCOS or pregnancies).

I've also added an `any()` around the logic for `has_insulin_purchases_within_180_days` since I otherwise got a warning that `summarise()` was "returning more (or less) than 1 row per group" (see full warning message below). 
I found out that after moving `add_insulin_purchases_cols()` down, we have multiple rows with the same PNR in the simulated data, and with the logic "is_insulin_gld_code & date <= (first_gld_date + days(180))" I believe one logical would be returned per row. Since we want to know whether an individual has *any* purchases within 180 days, I thought `any()` was the right implementation. Let me know what you think :) 

```
Warning message:
Returning more (or less) than 1 row per `summarise()` group was deprecated in dplyr 1.1.0.
ℹ Please use `reframe()` instead.
ℹ When switching from `summarise()` to `reframe()`, remember that `reframe()` always returns an
  ungrouped data frame and adjust accordingly.
Call `lifecycle::last_lifecycle_warnings()` to see where this warning was generated. 
```

Closes #336 

## Checklist

- [X] Ran `just run-all`
