### PR TITLE
style: 💄 change edge colour to black in function flow diagram

### DIFF
--- a/vignettes/function-flow.qmd
+++ b/vignettes/function-flow.qmd
@@ -82,11 +82,11 @@ flowchart TD
   end
 
   %% Styling
-  classDef default fill:#EEEEEE,color:#000000,stroke:#000000
+  classDef default fill:#EEEEEE, color:#000000, stroke:#000000
   classDef include fill:lightblue
   classDef exclude fill:orange
-  style classify_diabetes fill:#FFFFFF,color:#000000
-  style data_sources fill:#FFFFFF,color:#000000,stroke-width:0px
+  style classify_diabetes fill:#FFFFFF, color:#000000
+  style data_sources fill:#FFFFFF, color:#000000, stroke-width:0px
 ```
 
 The sections below are split into functions for inclusion and exclusion

--- a/vignettes/function-flow.qmd
+++ b/vignettes/function-flow.qmd
@@ -82,7 +82,7 @@ flowchart TD
   end
 
   %% Styling
-  classDef default fill:#EEEEEE,color:#000000
+  classDef default fill:#EEEEEE,color:#000000,stroke:#000000
   classDef include fill:lightblue
   classDef exclude fill:orange
   style classify_diabetes fill:#FFFFFF,color:#000000


### PR DESCRIPTION
## Description

Locally, they are black, but for some reason they turn blue on the website. So. I've established the `stroke` / edge colour to black explicitly now.

## Checklist

- [X] Ran `just run-all`
