### PR TITLE
fix: :bug: remove rows with NA in both T1 and T2D

### DIFF
--- a/R/classify-diabetes.R
+++ b/R/classify-diabetes.R
@@ -134,6 +134,8 @@ classify_diabetes <- function(
     classify_t1d() |>
     # If has_t1d is NA, t2d will also be NA
     dplyr::mutate(has_t2d = !.data$has_t1d) |>
+    # Drop those who don't have either type of diabetes
+    dplyr::filter(!(is.na(.data$has_t1d) & is.na(.data$has_t2d))) |>
     dplyr::select(
       "pnr",
       "stable_inclusion_date",


### PR DESCRIPTION
## Description

I guess we forgot to remove cases where the NAs propagate and leads to NA in `has_t1d` and `has_t2d`. So this removes those rows.

## Checklist

- [x] Ran `just run-all`
