### PR TITLE
fix: :bug: logic around `is.na()` in pregnancy event isn't needed

### DIFF
--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -141,8 +141,8 @@ algorithm <- function() {
     is_not_within_pregnancy_interval = list(
       register = NA,
       title = "Events that are not within a potential pregnancy interval",
-      logic = "NOT (has_pregnancy_event AND date >= (pregnancy_event_date - weeks(40)) AND date <= (pregnancy_event_date + weeks(12))) OR is.na(pregnancy_event_date)",
-      comments = "The potential pregnancy interval is defined as 40 weeks before and 12 weeks after the pregnancy event date."
+      logic = "NOT (has_pregnancy_event AND date >= (pregnancy_event_date - weeks(40)) AND date <= (pregnancy_event_date + weeks(12)))",
+      comments = "The potential pregnancy interval is defined as 40 weeks before and 12 weeks after the pregnancy event date (birth or miscarriage)."
     ),
     is_podiatrist_services = list(
       register = NA,


### PR DESCRIPTION
## Description

NAs will be propagated anyway (which is good), and in order for there to be a pregnancy event, there needs to be a pregnancy date. Plus, the `is.na()` is actually outside the `NOT`, which I think changes things.

## Checklist

- [x] Ran `just run-all`
