### PR TITLE
refactor: :recycle: deselect columns we don't need later

### DIFF
--- a/R/classify-diabetes.R
+++ b/R/classify-diabetes.R
@@ -128,12 +128,14 @@ classify_diabetes <- function(
       included_hba1c = hba1c_over_threshold
     ) |>
     add_insulin_purchases_cols() |>
-    dplyr::select-c(
+    dplyr::select(
+      -c(
         "atc",
         "indication_code",
         "volume",
         "apk",
         "is_hba1c"
+      )
     )
 
   # Join events, keeping only two earliest dates per "stream" -----


### PR DESCRIPTION
## Description

After the `add_*_cols()` functions there's a number of columns we don't use later on. This deselects those columns.

## Checklist

- [X] Ran `just run-all`
