### PR TITLE
docs: :page_facing_up: update LICENSE year and holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-YEAR: 2023
-COPYRIGHT HOLDER: Anders Aasted Isaksen
+YEAR: 2025
+COPYRIGHT HOLDER: Aarhus University

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2022-2023 Steno Diabetes Center Aarhus and Aarhus
+Copyright (c) 2022-2025 Steno Diabetes Center Aarhus and Aarhus
 University
 
 Permission is hereby granted, free of charge, to any person obtaining a


### PR DESCRIPTION
## Description

Technically the copyright holder is Aarhus University. Also updated the year.

## Checklist

- [x] Ran `just run-all`
