### PR TITLE
fix: :bug: don't need to drop indication code after exclusion

### DIFF
--- a/R/classify-diabetes.R
+++ b/R/classify-diabetes.R
@@ -142,7 +142,6 @@ classify_diabetes <- function(
     dplyr::select(
       -c(
         "atc",
-        "indication_code",
         "volume",
         "apk",
         "is_hba1c"


### PR DESCRIPTION
## Description

Indication code is needed later on, so don't drop it at the "exclusion" stage.

## Checklist

- [x] Ran `just run-all`
