### PR TITLE
fix: :bug: convert NAs to FALSE and drop any if TRUE for pregnancy

### DIFF
--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -138,10 +138,10 @@ algorithm <- function() {
       logic = "diagnosekode =~ '^(DO0[0-6]|DO8[0-4]|DZ3[37])'",
       comments = "These are recorded pregnancy endings like live births and miscarriages."
     ),
-    is_not_within_pregnancy_interval = list(
+    is_within_pregnancy_interval = list(
       register = NA,
-      title = "Events that are not within a potential pregnancy interval",
-      logic = "NOT (has_pregnancy_event AND date >= (pregnancy_event_date - weeks(40)) AND date <= (pregnancy_event_date + weeks(12)))",
+      title = "Events that are within a potential pregnancy interval",
+      logic = "has_pregnancy_event AND date >= (pregnancy_event_date - weeks(40)) AND date <= (pregnancy_event_date + weeks(12))",
       comments = "The potential pregnancy interval is defined as 40 weeks before and 12 weeks after the pregnancy event date (birth or miscarriage)."
     ),
     is_podiatrist_services = list(


### PR DESCRIPTION
## Description

This simplifies the issue we discussed in #379. At the point of calculating pregnancy interval, I converted all NAs to FALSE, since we only want those with TRUE to be dropped. Also converted to `any()` as in the discussion of #379.

I also simplified it to be `is_within_`, since a double (maybe even triple?) negative can be difficult to understand.

## Checklist

- [x] Ran `just run-all`
