### PR TITLE
fix: :bug: don't use `collect()` or `compute()` inside code, only outside

### DIFF
--- a/R/classify-diabetes.R
+++ b/R/classify-diabetes.R
@@ -169,8 +169,7 @@ classify_diabetes <- function(
       "raw_inclusion_date",
       "has_t1d",
       "has_t2d"
-    ) |>
-    dplyr::compute()
+    )
 }
 
 check_is_duckdb <- function(data, call = rlang::caller_env()) {

--- a/tests/testthat/test-classify-diabetes.R
+++ b/tests/testthat/test-classify-diabetes.R
@@ -22,9 +22,10 @@ test_that("expected cases are classified correctly", {
   ) |>
     dplyr::filter(grepl("\\d{2}_", .data$pnr)) |>
     dplyr::arrange(pnr) |>
-    dplyr::compute()
+    dplyr::collect()
 
-  expected <- edge_case_data$classified
+  expected <- edge_case_data$classified |>
+    dplyr::collect()
 
   expect_identical(actual, expected)
 })
@@ -43,7 +44,8 @@ test_that("expected non-cases are not classified", {
     bef = nc$bef,
     lmdb = nc$lmdb
   ) |>
-    dplyr::filter(grepl("\\d{2}_", .data$pnr))
+    dplyr::filter(grepl("\\d{2}_", .data$pnr)) |>
+    dplyr::collect()
 
   nc_pnrs <- names(non_cases_metadata())
   # No PNRs from non-cases have been classified.
@@ -71,7 +73,8 @@ test_that("casing of input variables doesn't matter", {
     lab_forsker = registers$lab_forsker,
     bef = registers$bef,
     lmdb = registers$lmdb
-  )
+  ) |>
+    dplyr::collect()
 
   # TODO: Need to update this when we have the expected output
   # expected_columns <- c(


### PR DESCRIPTION
## Description

Can't use `dplyr::compute()` within the package code. Let the user outside decide to either use `compute()` (which maintains a DuckDB connection) or `collect()` (which pulls it into R). When running multiple different DuckDB connections in a single script, it's better to use `collect()` since DuckDB seems to have trouble working with multiple in-process database tables at one time in the same script/session.

## Checklist

- [x] Ran `just run-all`
