### PR TITLE
fix: 🐛 changes to `drop_pregnancies()` to support the new refactored logic

### DIFF
--- a/R/drop.R
+++ b/R/drop.R
@@ -163,6 +163,8 @@ drop_pregnancies <- function(
       .data$volume,
       .data$date,
       .data$atc,
-      .data$apk
+      .data$apk,
+      .data$has_hba1c_over_threshold,
+      .data$has_gld_purchase
     )
 }


### PR DESCRIPTION
## Description

Adds two changes to `drop_pregnancies()` to support the refactored pregnancy logic:

- Changes one line that handles output from the pregnancy logic: from `is_within_pregnancy_interval = isTRUE(!!criteria)` to `is_within_pregnancy_interval = dplyr::coalesce(!!criteria, FALSE)`.
- Also contains the expanded `distinct()` call to remove duplicated rows at the end of the function (moved from  #379 )

Together with #379 , this should make the edge_case tests pass. I have not activated/"unskipped" the test yet.