### PR TITLE
chore: :see_no_evil: add the auto-added ignore for Quarto ipynb

### DIFF
--- a/vignettes/.gitignore
+++ b/vignettes/.gitignore
@@ -2,3 +2,4 @@
 *.R
 /.quarto/
 *_files
+**/*.quarto_ipynb


### PR DESCRIPTION
## Description

This gets added automatically, so just adding it here.
