### PR TITLE
perf: :zap: DuckDB can't use `rename_with()`, switch to `rename()`

### DIFF
--- a/R/select.R
+++ b/R/select.R
@@ -39,14 +39,14 @@ select_required_variables <- function(
 #' @return The same object type given.
 #' @keywords internal
 #'
-#' @examples
-#' \dontrun{
-#' tibble::tibble(A = 1:3, B = 4:6) |>
-#'   osdc:::column_names_to_lower()
-#' }
 column_names_to_lower <- function(data) {
+  # Needs to be a named vector for renaming.
+  lower_column_names <- names(data) |>
+    # This sets the names "attribute" of the vector.
+    rlang::set_names(tolower(names(data)))
   data |>
-    dplyr::rename_with(tolower)
+    # Inject the lowercase names into rename.
+    dplyr::rename(!!!lower_column_names)
 }
 
 #' Check data types of the register variables

--- a/man/column_names_to_lower.Rd
+++ b/man/column_names_to_lower.Rd
@@ -15,10 +15,4 @@ The same object type given.
 \description{
 Convert column names to lower case
 }
-\examples{
-\dontrun{
-tibble::tibble(A = 1:3, B = 4:6) |>
-  osdc:::column_names_to_lower()
-}
-}
 \keyword{internal}

--- a/tests/testthat/test-select-required-variables.R
+++ b/tests/testthat/test-select-required-variables.R
@@ -73,3 +73,30 @@ test_that("fails with unknown or incorrect register", {
   )
   expect_error(select_required_variables(unknown_register, "unknown_register"))
 })
+
+test_that("column names are converted to lower case", {
+  bef_mixed_case <- tibble::tibble(
+    PnR = "1",
+    KoEn = 1L,
+    FoEd_DaTo = "1"
+  )
+
+  expect_identical(
+    select_required_variables(bef_mixed_case, "bef"),
+    bef_complete
+  )
+
+  # And when converted to strict duckplyr
+  bef_as_duckdb <- tibble::tibble(
+    PnR = "1",
+    KoEn = 1L,
+    FoEd_DaTo = "1"
+  ) |>
+    duckplyr::as_duckdb_tibble(prudence = "stingy")
+
+  expect_identical(
+    select_required_variables(bef_as_duckdb, "bef") |>
+      dplyr::collect(),
+    bef_complete
+  )
+})


### PR DESCRIPTION
## Description

This switches to `rename()` instead of `rename_with()` as DuckDB has to pull the data into R to use it.

Related to #381

## Checklist

- [x] Ran `just run-all`
