### PR TITLE
fix: :bug: Non-cases test filter 

### DIFF
--- a/tests/testthat/test-classify-diabetes.R
+++ b/tests/testthat/test-classify-diabetes.R
@@ -43,7 +43,7 @@ test_that("expected non-cases are not classified", {
     bef = nc$bef,
     lmdb = nc$lmdb
   ) |>
-    dplyr::filter(grepl("\\d{2}_", .data$pnr)) |>
+    dplyr::filter(grepl("^.._", .data$pnr)) |>
     dplyr::collect()
 
   nc_pnrs <- names(non_cases_metadata())


### PR DESCRIPTION
## Description

Fixed the regex in the nc test so the filtering step now keeps any nc cases that might have been included (previously they were all excluded, and only the synthetic noise was kept, so it looked like the test was passing no matter the input from the nc-cases). Allows testing in #366 
