### PR TITLE
refactor: :recycle: replace `str_detect()` with `grepl` in algorithm

### DIFF
--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -218,7 +218,7 @@ get_algorithm_logic <- function(logic_name, algorithm = NULL) {
     # regex are defined with '=~', so convert them into a stringr function.
     stringr::str_replace_all(
       "([a-zA-Z0-9_]+) \\=\\~ '(.*?)'",
-      "stringr::str_detect(\\1, '\\2')"
+      "grepl('\\2', \\1)"
     )
 }
 

--- a/tests/testthat/test-algorithm.R
+++ b/tests/testthat/test-algorithm.R
@@ -27,16 +27,16 @@ test_that("`or` logic is converted to R logic", {
 
 test_that("single regex is converted to R logic", {
   get_algorithm_logic("regex", test_algorithm_logic) |>
-    expect_equal("stringr::str_detect(atc, '^A10')")
+    expect_equal("grepl('^A10', atc)")
 })
 
 test_that("`and` logic and regex within parentheses are converted to R logic", {
   # i.e., the regex is within a parenthesis
   get_algorithm_logic("regex_ands", test_algorithm_logic) |>
-    expect_equal("(stringr::str_detect(speciale, '^54')) & (barnmak != 0)")
+    expect_equal("(grepl('^54', speciale)) & (barnmak != 0)")
   get_algorithm_logic("two_regex", test_algorithm_logic) |>
     expect_equal(
-      "stringr::str_detect(atc, '^A10') & !(stringr::str_detect(atc, '^(A10BJ|A10D)'))"
+      "grepl('^A10', atc) & !(grepl('^(A10BJ|A10D)', atc))"
     )
 })
 


### PR DESCRIPTION
## Description

When fetching the changes from #392 the first error that appeared was that we can't use `stringr::str_detect()` with "stingy". So, this PR attempts to fix that using base R's `grepl` instead.

Related to #392 and #381 

## Checklist

- [X] Ran `just run-all`
