### PR TITLE
build: :hammer: add Jarl linter to justfile and CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,9 +23,12 @@ jobs:
 
       - name: Install
         uses: posit-dev/setup-air@v1
-
+  
       - name: Check
         run: air format . --check
+
+      - name: Lint
+        uses: etiennebacher/setup-jarl@v0.1.0
 
   cran-checks:
     runs-on: ${{ matrix.config.os }}

--- a/justfile
+++ b/justfile
@@ -49,6 +49,11 @@ url-check:
 style:
   air format .
 
+# From https://jarl.etiennebacher.com/#installation
+# Lint R code for any potential issues
+lint:
+  jarl check .
+
 # Build the pkgdown website
 build-website:
   #!/usr/bin/env Rscript


### PR DESCRIPTION
## Description

The original lintr R package was nice but it was too slow to use nicely in a dev workflow. This adds the new Jarl linter, written in Rust, that is super fast. I ran it  and there are no issues aside from the stuff in `dev/` (which will be removed in #421).

Closes #418

## Checklist

- [x] Ran `just run-all`
