### PR TITLE
build: :pushpin: pin to 4.2.0 for R, as per a CRAN note in the check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ URL: https://github.com/steno-aarhus/osdc,
     https://steno-aarhus.github.io/osdc/
 BugReports: https://github.com/steno-aarhus/osdc/issues
 Depends: 
-    R (>= 4.1.0)
+    R (>= 4.2.0)
 Imports: 
     checkmate,
     cli,


### PR DESCRIPTION
## Description

CRAN check had a note about updating to 4.2.0. So updated it.

See #426

## Checklist

- [x] Ran `just run-all`
