### PR TITLE
docs: :pencil2: fix link issues from `urlchecker::url_check()`

### DIFF
--- a/R/simulate-registers.R
+++ b/R/simulate-registers.R
@@ -87,7 +87,7 @@ create_fake_icd8 <- function(n) {
 #' @keywords internal
 #'
 #' @source The stored CSV is downloaded from the Danish Health Data Authority's
-#'   website at [medinfo.dk](https://medinfo.dk/sks/brows.php).
+#'   website at `medinfo.dk`
 create_fake_icd10 <- function(n) {
   # Downloaded from: https://medinfo.dk/sks/brows.php
   fs::path_package("osdc", "resources", "icd10-codes.csv") |>

--- a/man/create_fake_icd10.Rd
+++ b/man/create_fake_icd10.Rd
@@ -5,7 +5,7 @@
 \title{Create a vector of random ICD-10 diagnoses}
 \source{
 The stored CSV is downloaded from the Danish Health Data Authority's
-website at \href{https://medinfo.dk/sks/brows.php}{medinfo.dk}.
+website at \code{medinfo.dk}
 }
 \usage{
 create_fake_icd10(n)

--- a/vignettes/data-sources.qmd
+++ b/vignettes/data-sources.qmd
@@ -163,4 +163,5 @@ The above data is available through Statistics Denmark and the Danish
 Health Data Authority. Researchers must be affiliated with an approved
 research institute in Denmark and fees apply. Information on how to gain
 access to data can be found at
-<https://www.dst.dk/en/TilSalg/Forskningsservice>.
+`www.dst.dk/en/TilSalg/data-til-forskning` (URL often changes, so we
+can't link directly).

--- a/vignettes/rationale.qmd
+++ b/vignettes/rationale.qmd
@@ -30,13 +30,14 @@ concise version of those documents. We cover the:
 Many individual-level data (e.g. civil registration, public healthcare
 contacts, and drug prescriptions) are automatically collected on all
 residents in Denmark and stored in nationwide Danish registers by
-[Statistics Denmark](https://www.dst.dk/da/) and the [Danish Health Data
-Authority](https://sundhedsdatastyrelsen.dk/da). These agencies are
-legally allowed to give access to the register data for research
-purposes, which provides (authorized) researchers a set of common,
-extensive data sources to use for studies. Any researcher associated
-with an approved Danish research institute (mainly Danish universities)
-can apply for access, but fees and conditions apply.
+Statistics Denmark (`www.dst.dk`, URL often hits redirect limits, so we
+can't link directly) and the [Danish Health Data
+Authority](https://sundhedsdatastyrelsen.dk). These agencies are legally
+allowed to give access to the register data for research purposes, which
+provides (authorized) researchers a set of common, extensive data
+sources to use for studies. Any researcher associated with an approved
+Danish research institute (mainly Danish universities) can apply for
+access, but fees and conditions apply.
 
 Register data is generally accessed and processed by approved
 researchers on remote servers operated by Statistics Denmark and the


### PR DESCRIPTION
## Description

Some links don't link properly/hit a redirect limit, so converted them to regular text
with an explanation.

See #426

## Checklist

- [x] Ran `just run-all`
