### PR TITLE
perf: :zap: use `union_all()` for database version of `bind_rows()`

### DIFF
--- a/R/keep.R
+++ b/R/keep.R
@@ -8,7 +8,7 @@
 #' @inherit algorithm seealso
 keep_pregnancy_dates <- function(lpr2, lpr3) {
   lpr2 |>
-    dplyr::bind_rows(lpr3) |>
+    dplyr::union_all(lpr3) |>
     dplyr::filter(.data$is_pregnancy_code) |>
     dplyr::select(
       "pnr",
@@ -38,7 +38,7 @@ keep_pregnancy_dates <- function(lpr2, lpr3) {
 keep_diabetes_diagnoses <- function(lpr2, lpr3) {
   # Combine and process the two inputs
   lpr2 |>
-    dplyr::bind_rows(lpr3) |>
+    dplyr::union_all(lpr3) |>
     dplyr::filter(.data$is_diabetes_code) |>
     # Add logical helper variable to indicate a diabetes diagnosis.
     dplyr::mutate(from_diabetes_diagnosis = TRUE)


### PR DESCRIPTION
## Description

In DuckDB, there is no `bind_rows()`. So used `union_all()`, which is the equivalent.

Related to #381

## Checklist

- [x] Ran `just run-all`
