### PR TITLE
build: :wrench: ignore more files to lower package size

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,7 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\.quarto$
+^.*_files$
 ^LICENSE\.md$
 ^data-raw$
 ^\.github$
@@ -13,10 +15,11 @@
 ^_targets\.R$
 ^justfile$
 ^vignettes/articles$
-^vignettes/.quarto$
+^vignettes/\.quarto$
 ^doc$
 ^Meta$
 ^air.toml$
-^vignettes/*_files$
+^vignettes/.*_files$
 ^.cz.toml$
 ^CITATION.cff$
+^cran-comments\.md$


### PR DESCRIPTION
## Description

I think the `_files` folders were being added to the package, which increased it's size. So fixed this build ignore file.
