### PR TITLE
docs: :memo: add usage of `classify_diabetes()` in vignette

### DIFF
--- a/vignettes/osdc.qmd
+++ b/vignettes/osdc.qmd
@@ -53,10 +53,9 @@ registers() |>
 Let's create a fake dataset to show how to use the classification. We
 have a helper function `simulate_registers()` that takes a vector of
 register names and outputs a list of registers with simulated data.
-Because of the way that DuckDB connections work, we have to either
-load the data directly from a file as a DuckDB table, or convert
-a tibble into a DuckDB table. So we'll do that right after simulating 
-the data.
+Because of the way that DuckDB connections work, we have to either load
+the data directly from a file as a DuckDB table, or convert a tibble
+into a DuckDB table. So we'll do that right after simulating the data.
 
 ```{r}
 register_data <- registers() |> 
@@ -100,13 +99,21 @@ because we've created the simulated data to over-represent the values in
 the variables included in the algorithm that will lead to classifying
 into diabetes status.
 
-In a real scenario, the register data is probably too big to read into memory before being converted into a `duckdb_tibble`.  Therefore, we recommend that users first convert the individual register files into `.parquet` format on disk, with each register source contained in separate folders (e.g. all files from `kontakter` in one folder, `diagnoser` in another, `lpr_diag` in a third folder etc.). With the `arrow` package, each register data source can then be read in as a single `duckdb_tibble` by pointing the following code snippet to each of the Parquet folders. E.g. to load in `diagnoser`:
+In a real scenario, the register data is probably too big to read into
+memory before being converted into a `duckdb_tibble`. Therefore, we
+recommend that users first convert the individual register files into
+`.parquet` format on disk, with each register source contained in
+separate folders (e.g. all files from `kontakter` in one folder,
+`diagnoser` in another, `lpr_diag` in a third folder etc.). With the
+`arrow` package, each register data source can then be read in as a
+single `duckdb_tibble` by pointing the following code snippet to each of
+the Parquet folders. E.g. to load in `diagnoser`:
 
 ```{r}
   diagnoser <- diagnoser_parquet_folder |>
     arrow::open_dataset(unify_schemas = TRUE) |>
     arrow::to_duckdb()
-``` 
+```
 
 And that's all there is to this package! You can now save this dataset
 as a Parquet file for you or your collaborators on your DST project to


### PR DESCRIPTION
## Description

We didn't have any example uses of `classify_diabetes()` so added it here.

Depends on #410, build fails without.

Closes #452

## Checklist

- [ ] Ran `just run-all`
- [x] If docs were added, Markdown is formatted
