### PR TITLE
Add support for LPR A data

### DIFF
--- a/R/classify-diabetes.R
+++ b/R/classify-diabetes.R
@@ -6,6 +6,10 @@
 #' that data source, or at least the years you have and are interested
 #' in.
 #'
+#' @param lpr_a_diagnose The diagnoses information table from the LPR A patient register.
+#' Optional, but necessary if using LPR_A data (roughly from 2023 onward).
+#' @param lpr_a_kontakt The contacts information table from the LPR A patient register
+#' Optional, but necessary if using LPR_A data (roughly from 2023 onward).
 #' @param kontakter The contacts information table from the LPR3 patient register
 #' @param diagnoser The diagnoses information table from the LPR3 patient register
 #' @param lpr_diag The diagnoses information table from the LPR2 patient register
@@ -40,6 +44,8 @@
 #'   purrr::map(duckplyr::as_tbl)
 #'
 #' classify_diabetes(
+#'   lpr_a_kontakt = NULL,
+#'   lpr_a_diagnose = NULL
 #'   kontakter = register_data$kontakter,
 #'   diagnoser = register_data$diagnoser,
 #'   lpr_diag = register_data$lpr_diag,
@@ -51,6 +57,8 @@
 #'   lmdb = register_data$lmdb
 #' )
 classify_diabetes <- function(
+  lpr_a_kontakt = NULL,
+  lpr_a_diagnose = NULL,
   kontakter,
   diagnoser,
   lpr_diag,

--- a/R/dates.R
+++ b/R/dates.R
@@ -10,5 +10,5 @@
 #' @returns A Datetime column.
 #' @keywords internal
 as_sql_datetime <- function(x) {
-  dbplyr::sql(glue::glue("strptime({x}, ['%Y%m%d', '%Y-%m-%d'])"))
+  dbplyr::sql(glue::glue("strptime({x}, ['%Y%m%d', '%Y-%m-%d', '%Y-%m-%d %H:%M:%S'])"))
 }

--- a/R/edge-cases.R
+++ b/R/edge-cases.R
@@ -43,7 +43,8 @@ edge_cases <- function() {
     "20_nodm_female_o40_pcosT", 2, "19750101",
     "21_nodm_female_pregnancyT", 2, "19950101",
     "22_nodm_female_blank", 2, "19960101",
-    "23_t2d_gldT_1995_1999", 1, "19500101"
+    "23_t2d_gldT_1995_1999", 1, "19500101",
+    "24_t2d_lpr_a_only", 1, "19800101"
   ) |>
     dplyr::mutate(koen = as.integer(.data$koen))
 
@@ -221,6 +222,19 @@ edge_cases <- function() {
     "pnr21_dw01", "DO806", "A", "Nej"
   )
 
+  lpr_a_kontakt <- tibble::tribble(
+    ~pnr, ~dw_ek_kontakt, ~kont_ans_hovedspec, ~kont_starttidspunkt,
+    "24_t2d_lpr_a_only", "pnr24_dw01", "thoraxkirurgi", "2023-01-01 10:00:00",
+    "24_t2d_lpr_a_only", "pnr24_dw02", "kardiologi", "2024-01-01 10:00:00"
+  ) |>
+    dplyr::mutate(kont_starttidspunkt = as.POSIXct(.data$kont_starttidspunkt))
+
+  lpr_a_diagnose <- tibble::tribble(
+    ~dw_ek_kontakt, ~diag_kode, ~diag_kode_type, ~senere_afkraeftet,
+    "pnr24_dw01", "DE111", "A", "Nej",
+    "pnr24_dw02", "DE119", "A", "Nej"
+  )
+
   sysi <- tibble::tribble(
     ~pnr, ~barnmak, ~speciale, ~honuge,
     "04_t1d_oipF_endoT_majt1dT_i180T_itwo3T", 0, "54002", "0453",
@@ -315,7 +329,8 @@ edge_cases <- function() {
     "15_t2d_gldF_diagT_hba1cF_podF", "2023-01-01", "2023-01-01", FALSE, TRUE,
     "16_t2d_gldT_diagF_hba1cF_podF", "2013-04-01", "2013-04-01", FALSE, TRUE,
     "18_t2d_male_pcosF", "2023-04-01", "2023-04-01", FALSE, TRUE,
-    "23_t2d_gldT_1995_1999", NA, "1995-06-16", FALSE, TRUE
+    "23_t2d_gldT_1995_1999", NA, "1995-06-16", FALSE, TRUE,
+    "24_t2d_lpr_a_only", "2024-01-01", "2024-01-01", FALSE, TRUE
   ) |>
     dplyr::mutate(
       stable_inclusion_date = lubridate::as_date(.data$stable_inclusion_date),
@@ -331,6 +346,8 @@ edge_cases <- function() {
     lpr_diag = lpr_diag,
     kontakter = kontakter,
     diagnoser = diagnoser,
+    lpr_a_kontakt = lpr_a_kontakt,
+    lpr_a_diagnose = lpr_a_diagnose,
     sysi = sysi,
     sssy = sssy,
     lab_forsker = lab_forsker,

--- a/R/edge-cases.R
+++ b/R/edge-cases.R
@@ -329,8 +329,8 @@ edge_cases <- function() {
     "15_t2d_gldF_diagT_hba1cF_podF", "2023-01-01", "2023-01-01", FALSE, TRUE,
     "16_t2d_gldT_diagF_hba1cF_podF", "2013-04-01", "2013-04-01", FALSE, TRUE,
     "18_t2d_male_pcosF", "2023-04-01", "2023-04-01", FALSE, TRUE,
-    "23_t2d_gldT_1995_1999", NA, "1995-06-16", FALSE, TRUE,
-    "24_t2d_lpr_a_only", "2024-01-01", "2024-01-01", FALSE, TRUE
+    "23_t2d_gldT_1995_1999", NA, "1995-06-16", FALSE, TRUE # ,
+    # "24_t2d_lpr_a_only", "2024-01-01", "2024-01-01", FALSE, TRUE
   ) |>
     dplyr::mutate(
       stable_inclusion_date = lubridate::as_date(.data$stable_inclusion_date),

--- a/R/prepare-lpr.R
+++ b/R/prepare-lpr.R
@@ -5,6 +5,8 @@
 #'
 #' @param lpr_diag The LPR2 register containing diabetes diagnoses.
 #' @param lpr_adm The LPR2 register containing hospital admissions.
+#' @param lpr_a_diagnose The LPR A register containing diabetes diagnoses.
+#' @param lpr_a_kontakt A LPR A register containing hospital admissions.
 #'
 #' @return The same type as the input data, as a [duckplyr::duckdb_tibble()],
 #'  with the following columns:

--- a/R/select.R
+++ b/R/select.R
@@ -126,20 +126,20 @@ adapt_lpr_a_to_lpr3 <- function(lpr_a_kontakt, lpr_a_diagnose) {
     ) |>
     dplyr::select(
       # Rename to match LPR3 schema
-      cpr = .data$pnr,
-      dw_ek_kontakt,
-      dato_start,
-      hovedspeciale_ans = .data$kont_ans_hovedspec
+      "cpr" = "pnr",
+      "dw_ek_kontakt",
+      "dato_start",
+      "hovedspeciale_ans" = "kont_ans_hovedspec"
     )
 
   # Diagnoses information:
   diagnoser_adapted_from_lpr_a <- lpr_a_diagnose |>
     dplyr::select(
       # Rename to match LPR3 schema
-      dw_ek_kontakt,
-      diagnosekode = .data$diag_kode,
-      diagnosetype = .data$diag_kode_type,
-      senere_afkraeftet
+      "dw_ek_kontakt",
+      "diagnosekode" = "diag_kode",
+      "diagnosetype" = "diag_kode_type",
+      "senere_afkraeftet"
     )
 
   return(list(kontakter = kontakter_adapted, diagnoser = diagnoser_adapted))

--- a/R/select.R
+++ b/R/select.R
@@ -121,8 +121,8 @@ adapt_lpr_a_to_lpr3 <- function(lpr_a_kontakt, lpr_a_diagnose) {
   # Administrative information:
   kontakter_adapted_from_lpr_a <- lpr_a_kontakt |>
     dplyr::mutate(
-      # Convert LPR A timestamp to date type
-      dato_start = as.Date(.data$kont_starttidspunkt)
+      # Cast LPR A's <dttm> timestamp to <chr> so prepare_lpr3 receives a string
+      dato_start = as.character(.data$kont_starttidspunkt)
     ) |>
     dplyr::select(
       # Rename to match LPR3 schema

--- a/tests/testthat/test-classify-diabetes.R
+++ b/tests/testthat/test-classify-diabetes.R
@@ -27,6 +27,8 @@ actual <- classify_diabetes(
   diagnoser = cases_vs_nc$diagnoser,
   lpr_diag = cases_vs_nc$lpr_diag,
   lpr_adm = cases_vs_nc$lpr_adm,
+  lpr_a_kontakt = NULL,
+  lpr_a_diagnose = NULL,
   sysi = cases_vs_nc$sysi,
   sssy = cases_vs_nc$sssy,
   lab_forsker = cases_vs_nc$lab_forsker,


### PR DESCRIPTION
## Description

I tried to keep this short, but it looks like it's going to end up interfacing with a lot of the package, even if it's just a WIP for now.

This PR adds:

- a new helper function `adapt_lpr_a_to_lpr3()` to convert LPR A formatted data into LPR3 format which `prepare_lpr3()` supports.
- minor change to `as_sql_datetime()` to add '%Y-%m-%d %H:%M:%S' to the list of expected input formats (LPR A's date variable is apparently a `<dttm>` type)
- changes to `prepare_lpr3()` to accept LPR A inputs (and also allow the pipeline to run on projects that have no LPR A formatted data)
- a very basic LPR A test case to `edge_cases()`. Until the LPR A support is fully implemented in the package, tests are being run without evaluating LPR A data for now. So this case is currently removed from the table of expected cases.
- minor changes to `classify_diabetes()`: added LPR A parameters and docstrings for them.

Before being ready for review/merging, the simulated data generation and register documentation needs to be updated to incorporate LPR A data. 

Closes #326 

## Checklist

- [ ] Ran `just run-all`
- [ ] If docs were added, Markdown is formatted
