### PR TITLE
feat: :sparkles: implement LPR_A in classification and testing pipeline

### DIFF
--- a/R/algorithm.R
+++ b/R/algorithm.R
@@ -92,50 +92,50 @@ algorithm <- function() {
     lpr3_is_endocrinology_dept = list(
       register = "kontakter",
       title = "LPR3 endocrinology department",
-      logic = "hovedspeciale_ans  == 'medicinsk endokrinologi'",
+      logic = "kont_ans_hovedspec  == 'medicinsk endokrinologi'",
       comments = "`TRUE` when the department is endocrinology."
     ),
     lpr3_is_medical_dept = list(
       register = "kontakter",
       title = "LPR3 medical department",
       # TODO: We will need to make sure the Unicode character gets selected properly in real data.
-      logic = "hovedspeciale_ans %in% c('blandet medicin og kirurgi', 'intern medicin', 'geriatri', 'hepatologi', 'h\u00e6matologi', 'infektionsmedicin', 'kardiologi', 'medicinsk allergologi', 'medicinsk gastroenterologi', 'medicinsk lungesygdomme', 'nefrologi', 'reumatologi', 'palliativ medicin', 'akut medicin', 'dermato-venerologi', 'neurologi', 'onkologi', 'fysiurgi', 'tropemedicin')",
+      logic = "kont_ans_hovedspec %in% c('blandet medicin og kirurgi', 'intern medicin', 'geriatri', 'hepatologi', 'h\u00e6matologi', 'infektionsmedicin', 'kardiologi', 'medicinsk allergologi', 'medicinsk gastroenterologi', 'medicinsk lungesygdomme', 'nefrologi', 'reumatologi', 'palliativ medicin', 'akut medicin', 'dermato-venerologi', 'neurologi', 'onkologi', 'fysiurgi', 'tropemedicin')",
       comments = "`TRUE` when the department is other medical departments (than endocrinology)."
     ),
     lpr3_is_needed_code = list(
       register = "diagnoser",
       title = "LPR3 codes used throughout the algorithm",
-      logic = "diagnosekode =~ '^(DO0[0-6]|DO8[0-4]|DZ3[37]|DE1[0-4])' AND (diagnosetype == 'A' OR diagnosetype == 'B') AND (senere_afkraeftet == 'Nej')",
-      comments = "`A` `diagnosekode` means primary diagnosis and `senere_afkraeftet` means diagnosis was later retracted."
+      logic = "diag_kode =~ '^(DO0[0-6]|DO8[0-4]|DZ3[37]|DE1[0-4])' AND (diag_type == 'A' OR diag_type == 'B') AND (senere_afkraeftet == 'Nej')",
+      comments = "`A` `diag_kode` means primary diagnosis and `senere_afkraeftet` means diagnosis was later retracted."
     ),
     lpr3_is_primary_diagnosis = list(
       register = "diagnoser",
       title = "LPR3 primary diagnosis",
-      logic = "diagnosetype == 'A'",
+      logic = "diag_type == 'A'",
       comments = ""
     ),
     lpr3_is_t1d_code = list(
       register = "diagnoser",
       title = "LPR3 diagnoses codes for T1D",
-      logic = "diagnosekode =~ '^(DE10)'",
+      logic = "diag_kode =~ '^(DE10)'",
       comments = ""
     ),
     lpr3_is_t2d_code = list(
       register = "diagnoser",
       title = "LPR3 diagnoses codes for T2D",
-      logic = "diagnosekode =~ '^(DE11)'",
+      logic = "diag_kode =~ '^(DE11)'",
       comments = ""
     ),
     lpr3_is_diabetes_code = list(
       register = "diagnoser",
       title = "LPR3 diagnoses codes for diabetes",
-      logic = "diagnosekode =~ '^DE1[0-4]'",
+      logic = "diag_kode =~ '^DE1[0-4]'",
       comments = "This is a general diabetes code, not specific to T1D or T2D."
     ),
     lpr3_is_pregnancy_code = list(
       register = "diagnoser",
       title = "ICD-10 diagnoses codes for pregnancy-related outcomes",
-      logic = "diagnosekode =~ '^(DO0[0-6]|DO8[0-4]|DZ3[37])'",
+      logic = "diag_kode =~ '^(DO0[0-6]|DO8[0-4]|DZ3[37])'",
       comments = "These are recorded pregnancy endings like live births and miscarriages."
     ),
     is_within_pregnancy_interval = list(

--- a/R/classify-diabetes.R
+++ b/R/classify-diabetes.R
@@ -6,8 +6,10 @@
 #' that data source, or at least the years you have and are interested
 #' in.
 #'
-#' @param kontakter The contacts information table from the LPR3 patient register
-#' @param diagnoser The diagnoses information table from the LPR3 patient register
+#' @param kontakter The contacts information table from the deprecated LPR_F-formatted LPR3 patient register
+#' @param diagnoser The diagnoses information table from the deprecated LPR_F-formatted LPR3 patient register
+#' @param lpr_a_kontakt The contacts information table from the LPR_A-formatted LPR3 patient register
+#' @param lpr_a_diagnose The diagnoses information table from the LPR_A-formatted LPR3 patient register
 #' @param lpr_diag The diagnoses information table from the LPR2 patient register
 #' @param lpr_adm The administrative information table from the LPR2 patient register
 #' @param sysi The SYSI table from the health service register
@@ -40,8 +42,10 @@
 #'   purrr::map(duckplyr::as_tbl)
 #'
 #' classify_diabetes(
-#'   kontakter = register_data$kontakter,
-#'   diagnoser = register_data$diagnoser,
+#'   kontakter = NULL,
+#'   diagnoser = NULL,
+#'   lpr_a_kontakt = register_data$lpr_a_kontakt,
+#'   lpr_a_diagnose = register_data$lpr_a_diagnose,
 #'   lpr_diag = register_data$lpr_diag,
 #'   lpr_adm = register_data$lpr_adm,
 #'   sysi = register_data$sysi,
@@ -51,8 +55,10 @@
 #'   lmdb = register_data$lmdb
 #' )
 classify_diabetes <- function(
-  kontakter,
-  diagnoser,
+  kontakter = NULL,
+  diagnoser = NULL,
+  lpr_a_kontakt,
+  lpr_a_diagnose,
   lpr_diag,
   lpr_adm,
   sysi,
@@ -72,6 +78,8 @@ classify_diabetes <- function(
   registers <- list(
     kontakter = kontakter,
     diagnoser = diagnoser,
+    lpr_a_kontakt = lpr_a_kontakt,
+    lpr_a_diagnose = lpr_a_diagnose,
     lpr_diag = lpr_diag,
     lpr_adm = lpr_adm,
     sysi = sysi,
@@ -80,29 +88,48 @@ classify_diabetes <- function(
     bef = bef,
     lmdb = lmdb
   ) |>
+    purrr::discard(is.null) |>
     purrr::map(verify_duckdb)
 
   # Verification step -----
-  kontakter <- select_required_variables(registers$kontakter, "kontakter")
-  diagnoser <- select_required_variables(registers$diagnoser, "diagnoser")
-  lpr_diag <- select_required_variables(registers$lpr_diag, "lpr_diag")
-  lpr_adm <- select_required_variables(registers$lpr_adm, "lpr_adm")
-  sysi <- select_required_variables(registers$sysi, "sysi")
-  sssy <- select_required_variables(registers$sssy, "sssy")
-  lab_forsker <- select_required_variables(registers$lab_forsker, "lab_forsker")
-  bef <- select_required_variables(registers$bef, "bef")
-  lmdb <- select_required_variables(registers$lmdb, "lmdb")
+  registers <- registers |>
+    purrr::imap(\(table, name) select_required_variables(table, name))
 
   # Initially processing -----
+
+  # LPR2: mandatory
+  # (due to need for data on pregnancies to censor GLDs purchased due to GDM)
   lpr2 <- prepare_lpr2(
-    lpr_diag = lpr_diag,
-    lpr_adm = lpr_adm
+    lpr_diag = registers$lpr_diag,
+    lpr_adm = registers$lpr_adm
   )
 
-  lpr3 <- prepare_lpr3(
-    kontakter = kontakter,
-    diagnoser = diagnoser
-  )
+  # LPR3: LPR_F or LPR_A can be missing
+
+  # Check if LPR_F inputs exist in the verified registers list
+  if (all(c("kontakter", "diagnoser") %in% names(registers))) {
+    lpr3_f <- prepare_lpr_f(
+      kontakter = registers$kontakter,
+      diagnoser = registers$diagnoser
+    )
+  }
+
+  # Check if LPR_F inputs exist in the verified registers list
+  if (all(c("lpr_a_kontakt", "lpr_a_diagnose") %in% names(registers))) {
+    lpr3_a <- prepare_lpr_a(
+      lpr_a_kontakt = registers$lpr_a_kontakt,
+      lpr_a_diagnose = registers$lpr_a_diagnose
+    )
+  }
+
+  # Bind whatever LPR3 data is present
+  # Handles only LPR_F, only LPR_A, neither, or both.
+  # In the latter case, the user must ensure no overlap between LPR_F and LPR_A inputs
+  lpr3 <- mget(c("lpr3_a", "lpr3_f"), ifnotfound = list(NULL)) |>
+    # 1. Remove NULLs so the list only contains valid tables
+    purrr::compact() |>
+    # 2. Use reduce to apply union_all if more than one element exists
+    purrr::reduce(dplyr::union_all)
 
   pregnancy_dates <- keep_pregnancy_dates(
     lpr2 = lpr2,
@@ -128,21 +155,21 @@ classify_diabetes <- function(
     )
 
   podiatrist_services <- keep_podiatrist_services(
-    sysi = sysi,
-    sssy = sssy
+    sysi = registers$sysi,
+    sssy = registers$sssy
   )
 
   gld_purchases <- keep_gld_purchases(
-    lmdb = lmdb
+    lmdb = registers$lmdb
   )
 
   hba1c_over_threshold <- keep_hba1c(
-    lab_forsker = lab_forsker
+    lab_forsker = registers$lab_forsker
   )
 
   # Drop steps -----
   gld_hba1c_after_drop_steps <- gld_purchases |>
-    drop_pcos(bef = bef) |>
+    drop_pcos(bef = registers$bef) |>
     drop_pregnancies(
       pregnancy_dates = pregnancy_dates,
       included_hba1c = hba1c_over_threshold

--- a/R/classify-diabetes.R
+++ b/R/classify-diabetes.R
@@ -102,10 +102,32 @@ classify_diabetes <- function(
     lpr_adm = registers$lpr_adm
   )
 
-  lpr3 <- prepare_lpr3(
-    kontakter = registers$kontakter,
-    diagnoser = registers$diagnoser
-  )
+  # LPR3: Handle that LPR_F or LPR_A can be missing depending on the project
+
+  # Check if LPR_F inputs exist in the verified registers list
+  if (all(c("kontakter", "diagnoser") %in% names(registers))) {
+    lpr3_f <- prepare_lpr_f(
+      kontakter = registers$kontakter,
+      diagnoser = registers$diagnoser
+    )
+  }
+
+  # Check if LPR_F inputs exist in the verified registers list
+  if (all(c("lpr_a_kontakt", "lpr_a_diagnose") %in% names(registers))) {
+    lpr3_a <- prepare_lpr_a(
+      lpr_a_kontakt = registers$lpr_a_kontakt,
+      lpr_a_diagnose = registers$lpr_a_diagnose
+    )
+  }
+
+  # Bind whatever LPR3 data is present
+  # Handles only LPR_F, only LPR_A, neither, or both.
+  # In the latter case, the user must ensure no overlap between LPR_F and LPR_A inputs
+  lpr3 <- mget(c("lpr3_a", "lpr3_f"), ifnotfound = list(NULL)) |>
+    # Remove NULL elements:
+    purrr::compact() |>
+    # Row-bind all available LPR sources:
+    purrr::reduce(dplyr::union_all)
 
   pregnancy_dates <- keep_pregnancy_dates(
     lpr2 = lpr2,

--- a/R/edge-cases.R
+++ b/R/edge-cases.R
@@ -13,7 +13,7 @@
 #'
 #' @return A named list of 9  [tibble::tibble()] objects, each representing a
 #'   different health register: `bef`, `lmdb`, `lpr_adm`, `lpr_diag`,
-#'   `kontakter`, `diagnoser`, `sysi`, `sssy`, and `lab_forsker`.
+#'   `kontakter`, `diagnoser`, `lpr_a_kontakt`, `lpr_a_diagnose`, `sysi`, `sssy`, and `lab_forsker`.
 #' @export
 #'
 #' @examples
@@ -172,6 +172,74 @@ edge_cases <- function() {
     "pnr16_rec01", "DZ371", "A",
     "pnr21_rec01", "DZ371", "A"
   )
+
+  lpr_a_kontakt <- tibble::tribble(
+    ~pnr, ~dw_ek_kontakt, ~kont_ans_hovedspec, ~kont_starttidspunkt,
+    "01_t1d_oipT_anyt1dT", "pnr01_dw01", "medicinsk endokrinologi", "20210515",
+    "02_t2d_oipT_anyt1dF", "pnr02_dw01", "thoraxkirurgi", "20220616",
+    "03_t2d_oipF_anyt1dF", "pnr03_dw01", "kardiologi", "20200717",
+    "04_t1d_oipF_endoT_majt1dT_i180T_itwo3T", "pnr04_dw01", "medicinsk endokrinologi", "20230120",
+    "05_t2d_oipF_endoT_majt1dT_i180T_itwo3F", "pnr05_dw01", "medicinsk endokrinologi", "20230221",
+    "06_t2d_oipF_endoT_majt1dT_i180F_itwo3T", "pnr06_dw01", "medicinsk endokrinologi", "20230322",
+    "07_t2d_oipF_endoT_majt1dF_i180T_itwo3T", "pnr07_dw01", "medicinsk endokrinologi", "20220423",
+    "07_t2d_oipF_endoT_majt1dF_i180T_itwo3T", "pnr07_dw02", "geriatri", "20230423",
+    "08_t1d_oipF_medT_majt1dT_i180T_itwo3T", "pnr08_dw01", "kardiologi", "20230120",
+    "08_t1d_oipF_medT_majt1dT_i180T_itwo3T", "pnr08_dw02", "kardiologi", "20240120",
+    "09_t2d_oipF_medT_majt1dT_i180T_itwo3F", "pnr09_dw01", "kardiologi", "20240221",
+    "10_t2d_oipF_medT_majt1dT_i180F_itwo3T", "pnr10_dw01", "kardiologi", "20240322",
+    "11_t2d_oipF_medT_majt1dF_i180T_itwo3T", "pnr11_dw01", "kardiologi", "20230423",
+    "11_t2d_oipF_medT_majt1dF_i180T_itwo3T", "pnr11_dw02", "medicinsk endokrinologi", "20240423",
+    "11_t2d_oipF_medT_majt1dF_i180T_itwo3T", "pnr11_dw03", "thoraxkirurgi", "20240616",
+    "12_nodm_gldF_diagF_hba1cF_podF", "pnr12_dw01", "kardiologi", "20210423",
+    "14_t2d_gldF_diagF_hba1cT_podF", "pnr14_dw01", "gynaekologi og obstetrik", "20240101",
+    "15_t2d_gldF_diagT_hba1cF_podF", "pnr15_dw01", "urologi", "20230101",
+    "16_t2d_gldT_diagF_hba1cF_podF", "pnr16_dw01", "gynaekologi og obstetrik", "20240101",
+    "21_nodm_female_pregnancyT", "pnr21_dw01", "gynaekologi og obstetrik", "20240101"
+  ) |>
+    dplyr::mutate(
+      kont_starttidspunkt = as.POSIXct(
+        .data$kont_starttidspunkt,
+        format = "%Y%m%d",
+        tz = "UTC"
+      )
+    )
+
+  lpr_a_diagnose <- tibble::tribble(
+    ~dw_ek_kontakt, ~diag_kode, ~diag_type, ~senere_afkraeftet,
+    "pnr01_dw01", "DE101", "A", "Nej",
+    "pnr02_dw01", "DE102", "A", "Nej",
+    "pnr03_dw01", "DE103", "A", "Nej",
+    "pnr04_dw01", "DE104", "A", "Nej",
+    "pnr04_dw02", "DE115", "B", "Nej",
+    "pnr04_dw02", "DE119", "B", "Nej",
+    "pnr05_dw01", "DE101", "A", "Nej",
+    "pnr06_dw01", "DE102", "A", "Nej",
+    "pnr07_dw01", "DE103", "A", "Nej",
+    "pnr07_dw01", "DE109", "B", "Nej",
+    "pnr07_dw02", "DE104", "A", "Nej",
+    "pnr07_dw02", "DE108", "B", "Nej",
+    "pnr08_dw01", "DE114", "A", "Nej",
+    "pnr08_dw02", "DE105", "A", "Nej",
+    "pnr08_dw02", "DE119", "B", "Nej",
+    "pnr09_dw01", "DE10", "A", "Nej",
+    "pnr10_dw01", "DE101", "A", "Nej",
+    "pnr11_dw01", "DE112", "A", "Nej",
+    "pnr11_dw01", "DE102", "B", "Nej",
+    "pnr11_dw02", "DE109", "B", "Nej",
+    "pnr11_dw02", "DI739", "B", "Nej",
+    "pnr11_dw03", "DE102", "A", "Nej",
+    "pnr12_dw01", "DI25", "A", "Nej",
+    "pnr12_dw01", "DE110", "A", "Ja",
+    "pnr14_dw01", "DO041", "A", "Nej",
+    "pnr15_dw01", "DI25", "A", "Nej",
+    "pnr15_dw01", "DE110", "B", "Nej",
+    "pnr16_dw01", "DO822", "A", "Nej",
+    "pnr21_dw01", "DO806", "A", "Nej"
+  )
+
+  # LPR_F: deprecated
+  # kontakter & diagnoser tables
+  # Same content/observations as lpr_a_kontakt & lpr_a_diagnose, just different format.
 
   kontakter <- tibble::tribble(
     ~cpr, ~dw_ek_kontakt, ~hovedspeciale_ans, ~dato_start,
@@ -346,6 +414,8 @@ edge_cases <- function() {
     lpr_diag = lpr_diag,
     kontakter = kontakter,
     diagnoser = diagnoser,
+    lpr_a_kontakt = lpr_a_kontakt,
+    lpr_a_diagnose = lpr_a_diagnose,
     sysi = sysi,
     sssy = sssy,
     lab_forsker = lab_forsker,

--- a/R/non-cases.R
+++ b/R/non-cases.R
@@ -11,7 +11,7 @@
 #'
 #' @return A named list of 9  [tibble::tibble()] objects, each representing a
 #'   different health register: `bef`, `lmdb`, `lpr_adm`, `lpr_diag`,
-#'   `kontakter`, `diagnoser`, `sysi`, `sssy`, and `lab_forsker`.
+#'   `kontakter`, `diagnoser`, `lpr_a_kontakt`, `lpr_a_diagnose`, `sysi`, `sssy`, and `lab_forsker`.
 #' @export
 #'
 #' @examples
@@ -67,6 +67,36 @@ non_cases <- function() {
   )
 
   # LPR3 is from 2019 onwards
+
+  # LPR_A (superseded LPR_F):
+  lpr_a_kontakt <- tibble::tribble(
+    ~pnr, ~dw_ek_kontakt, ~kont_ans_hovedspec, ~kont_starttidspunkt,
+    "nc_pcos_1", "1", "medicinsk endokrinologi", "20210101",
+    "nc_pcos_2", "1", "medicinsk endokrinologi", "20190101",
+    "nc_pcos_3", "1", "medicinsk endokrinologi", "20190101",
+    "nc_preg_3", "1", "abc", "20200101",
+    "nc_preg_4", "1", "abc", "20200101",
+    "nc_preg_3", "2", "abc", "20200101",
+    "nc_preg_4", "3", "abc", "20200101",
+  ) |>
+    dplyr::mutate(
+      kont_starttidspunkt = as.POSIXct(
+        .data$kont_starttidspunkt,
+        format = "%Y%m%d",
+        tz = "UTC"
+      )
+    )
+
+  lpr_a_diagnose <- tibble::tribble(
+    ~dw_ek_kontakt, ~diag_kode, ~diag_type, ~senere_afkraeftet,
+    # diagnosis noise (not diabetes)
+    "1", "DI10", "A", "Nej",
+    # Pregnancy
+    "2", "DO00", "A", "Nej",
+    "3", "DZ33", "A", "Nej",
+  )
+
+  # LPR_F: deprecated, but same as LPR_A:
   kontakter <- tibble::tribble(
     ~cpr, ~dw_ek_kontakt, ~hovedspeciale_ans, ~dato_start,
     "nc_pcos_1", "1", "medicinsk endokrinologi", "20210101",
@@ -131,6 +161,8 @@ non_cases <- function() {
   list(
     bef = bef,
     lmdb = lmdb,
+    lpr_a_kontakt = lpr_a_kontakt,
+    lpr_a_diagnose = lpr_a_diagnose,
     lpr_adm = lpr_adm,
     lpr_diag = lpr_diag,
     kontakter = kontakter,

--- a/tests/testthat/test-classify-diabetes.R
+++ b/tests/testthat/test-classify-diabetes.R
@@ -5,11 +5,24 @@ cases <- edge_cases()
 nc <- non_cases()
 
 join_registers <- function(name) {
-  dplyr::bind_rows(
+  combined_df <- dplyr::bind_rows(
     cases[[name]],
     sim_data[[name]],
     nc[[name]]
   )
+
+  # Bind_rows reverses the order of attributes, which upsets DuckDB
+  # Solution/work-around: Reconstruct POSIXct columns from scratch and
+  # enforce canonical attribute order
+  combined_df |>
+    dplyr::mutate(across(where(lubridate::is.POSIXct), \(x) {
+      # Strip to raw seconds (numeric)
+      raw_vals <- as.numeric(x)
+
+      # Rebuild strictly as UTC POSIXct
+      # This forces 'class' to be set first, then 'tzone'
+      structure(raw_vals, class = c("POSIXct", "POSIXt"), tzone = "UTC")
+    }))
 }
 
 cases_vs_nc <- sim_data |>
@@ -22,9 +35,50 @@ cases_vs_nc <- sim_data |>
   purrr::map(duckplyr::as_duckdb_tibble) |>
   purrr::map(duckplyr::as_tbl)
 
-actual <- classify_diabetes(
-  kontakter = cases_vs_nc$kontakter,
+# Test with only LPR3 data from LPR A
+actual_only_lpr_a <- classify_diabetes(
+  diagnoser = NULL,
+  kontakter = NULL,
+  lpr_a_diagnose = cases_vs_nc$lpr_a_diagnose,
+  lpr_a_kontakt = cases_vs_nc$lpr_a_kontakt,
+  lpr_diag = cases_vs_nc$lpr_diag,
+  lpr_adm = cases_vs_nc$lpr_adm,
+  sysi = cases_vs_nc$sysi,
+  sssy = cases_vs_nc$sssy,
+  lab_forsker = cases_vs_nc$lab_forsker,
+  bef = cases_vs_nc$bef,
+  lmdb = cases_vs_nc$lmdb
+) |>
+  dplyr::collect()
+
+# Test with only LPR3 data from LPR F
+actual_only_lpr_f <- classify_diabetes(
   diagnoser = cases_vs_nc$diagnoser,
+  kontakter = cases_vs_nc$kontakter,
+  lpr_a_diagnose = NULL,
+  lpr_a_kontakt = NULL,
+  lpr_diag = cases_vs_nc$lpr_diag,
+  lpr_adm = cases_vs_nc$lpr_adm,
+  sysi = cases_vs_nc$sysi,
+  sssy = cases_vs_nc$sssy,
+  lab_forsker = cases_vs_nc$lab_forsker,
+  bef = cases_vs_nc$bef,
+  lmdb = cases_vs_nc$lmdb
+) |>
+  dplyr::collect()
+
+# Test with a mix of LPR3 data from LPR A and F
+
+lpr_f_part <- cases_vs_nc$kontakter |>
+  dplyr::filter(dplyr::row_number() %in% 1:10)
+lpr_a_part <- cases_vs_nc$lpr_a_kontakt |>
+  dplyr::filter(!dplyr::row_number() %in% 1:10)
+
+actual_mix_lpr3 <- classify_diabetes(
+  diagnoser = cases_vs_nc$diagnoser,
+  kontakter = lpr_f_part,
+  lpr_a_diagnose = cases_vs_nc$lpr_a_diagnose,
+  lpr_a_kontakt = lpr_a_part,
   lpr_diag = cases_vs_nc$lpr_diag,
   lpr_adm = cases_vs_nc$lpr_adm,
   sysi = cases_vs_nc$sysi,
@@ -37,19 +91,44 @@ actual <- classify_diabetes(
 
 test_that("expected cases are classified correctly", {
   expected <- cases$classified
-  actual_cases <- actual |>
+  actual_cases_lpr_a <- actual_only_lpr_f |>
     dplyr::filter(grepl("\\d{2}_", .data$pnr)) |>
     dplyr::arrange(pnr)
-  expect_identical(actual_cases, expected)
+
+  expect_identical(actual_cases_lpr_a, expected)
+
+  actual_cases_lpr_f <- actual_only_lpr_a |>
+    dplyr::filter(grepl("\\d{2}_", .data$pnr)) |>
+    dplyr::arrange(pnr)
+
+  expect_identical(actual_cases_lpr_f, expected)
+
+  actual_cases_mix_lpr3 <- actual_mix_lpr3 |>
+    dplyr::filter(grepl("\\d{2}_", .data$pnr)) |>
+    dplyr::arrange(pnr)
+
+  expect_identical(actual_cases_mix_lpr3, expected)
 })
 
 test_that("expected non-cases are not classified", {
   nc_pnrs <- names(non_cases_metadata())
   # No PNRs from non-cases have been classified.
-  expected_pnrs <- actual |>
+  expected_pnrs_only_lpr_f <- actual_only_lpr_f |>
     dplyr::filter(.data$pnr %in% nc_pnrs) |>
     dplyr::pull(.data$pnr) |>
     unique()
 
-  expect_identical(expected_pnrs, character(0))
+  expected_pnrs_only_lpr_a <- actual_only_lpr_a |>
+    dplyr::filter(.data$pnr %in% nc_pnrs) |>
+    dplyr::pull(.data$pnr) |>
+    unique()
+
+  expected_pnrs_mix_lpr3 <- actual_mix_lpr3 |>
+    dplyr::filter(.data$pnr %in% nc_pnrs) |>
+    dplyr::pull(.data$pnr) |>
+    unique()
+
+  expect_identical(expected_pnrs_only_lpr_f, character(0))
+  expect_identical(expected_pnrs_only_lpr_a, character(0))
+  expect_identical(expected_pnrs_mix_lpr3, character(0))
 })

--- a/tests/testthat/test-classify-variable-casing.R
+++ b/tests/testthat/test-classify-variable-casing.R
@@ -7,8 +7,10 @@ test_that("casing of input variables doesn't matter", {
     purrr::map(duckplyr::as_tbl)
 
   actual <- classify_diabetes(
-    kontakter = registers$kontakter,
-    diagnoser = registers$diagnoser,
+    kontakter = NULL,
+    diagnoser = NULL,
+    lpr_a_kontakt = registers$lpr_a_kontakt,
+    lpr_a_diagnose = registers$lpr_a_diagnose,
     lpr_diag = registers$lpr_diag,
     lpr_adm = registers$lpr_adm,
     sysi = registers$sysi,

--- a/vignettes/osdc.qmd
+++ b/vignettes/osdc.qmd
@@ -97,10 +97,12 @@ explicit about this:
 ```{r}
 bef <- register_data$bef
 diagnoser <- register_data$diagnoser
+kontakter <- register_data$kontakter
+lpr_a_diagnose <- register_data$lpr_a_diagnose
+lpr_a_kontakt <- register_data$lpr_a_kontakt
 lmdb <- register_data$lmdb
 lpr_adm <- register_data$lpr_adm
 lpr_diag <- register_data$lpr_diag
-kontakter <- register_data$kontakter
 sysi <- register_data$sysi
 sssy <- register_data$sssy
 lab_forsker <- register_data$lab_forsker
@@ -109,12 +111,18 @@ lab_forsker <- register_data$lab_forsker
 ### Step 4: Run the classification
 
 Now, we're ready to run the classification algorithm. Pass each register
-to `classify_diabetes()`:
+to `classify_diabetes()`. To show all potential input registers in this
+example, we use LPR3 data from both the deprecated LPR_F format
+(`kontakter` and `diagnoser`), as well as the current LPR_A format
+(`lpr_a_kontakt` and `lpr_a_diagnose`), but you can choose to use only
+one or the other of these formats by setting the inputs to `NULL`:
 
 ```{r}
 classified_diabetes <- classify_diabetes(
   kontakter = kontakter,
   diagnoser = diagnoser,
+  lpr_a_diagnose = lpr_a_diagnose,
+  lpr_a_kontakt = lpr_a_kontakt,
   lpr_diag = lpr_diag,
   lpr_adm = lpr_adm,
   sysi = sysi,
@@ -156,7 +164,7 @@ The output is a table with one row per classified individual and five
 columns:
 
 | Column | Description |
-|------------------------------------|------------------------------------|
+|----|----|
 | `pnr` | The pseudonymised personal identification number. |
 | `stable_inclusion_date` | The inclusion date, which is the date of the second inclusion event, but only if it falls within a period of reliable data coverage set by the `stable_inclusion_start_date` parameter (from 1998 onward by default). `NA` for earlier dates. |
 | `raw_inclusion_date` | The date of the second inclusion event without setting `NA` for date earlier than the `stable_inclusion_start_date`. |


### PR DESCRIPTION
## Description

Split from #490
Depends on #492, #493, #494

Adds function to process LPR_A data: `prepare_lpr_a()` and implements it in `classify_diabetes()`. The old `prepare_lpr3()` function is renamed to `prepare_lpr_f()` and the algorithm logic is updated to expect LPR_A variable names by default.

Also contains changes to test data and testing pipeline to enable testing of the pipeline after the addition of LPR_A data.

Small changes to the osdc vignette to allow it to run with the new changes (and a bit a documentation relevant to real-world use of LPR A data)



