### PR TITLE
build: comment out `ubuntu-latest devel` in `build` workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,8 @@ jobs:
           - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          # TODO: Uncomment again before new release to CRAN.
+          # - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:


### PR DESCRIPTION
## Description

Just until we release to CRAN again, so we don't have to wait for it to complete in every PR.
