### PR TITLE
fix: :bug: `.data$` in tidyselect is being deprecated

### DIFF
--- a/R/get-variables.R
+++ b/R/get-variables.R
@@ -20,5 +20,5 @@ get_required_variables <- function(register) {
   checkmate::assert_choice(register, get_register_abbrev())
   register <- rlang::arg_match(register, get_register_abbrev())
   registers()[[register]]$variables |>
-    dplyr::pull(.data$name)
+    dplyr::pull("name")
 }

--- a/R/simulate-registers.R
+++ b/R/simulate-registers.R
@@ -76,7 +76,7 @@ create_fake_atc <- function(n) {
   codeCollection::ATCKoodit |>
     tibble::as_tibble() |>
     dplyr::filter(stringr::str_length(.data$Koodi) == 7) |>
-    dplyr::pull(.data$Koodi) |>
+    dplyr::pull("Koodi") |>
     sample(n, replace = TRUE)
 }
 # jarl-ignore-end unused_function


### PR DESCRIPTION
## Description

A small fix to use `""` rather than `.data$` for some functions.

## Checklist

- [x] Ran `just run-all`
