### PR TITLE
build: :bug: fix just recipe shebang by adding `/env`

### DIFF
--- a/justfile
+++ b/justfile
@@ -74,7 +74,7 @@ format-r: _format-r-styler _format-r-air
 
 # Styler formats Quarto files
 @_format-r-styler:
-  #!/usr/bin/Rscript
+  #!/usr/bin/env Rscript
   styler::style_dir()
 
 # Format Markdown files


### PR DESCRIPTION
My `just run-all` started failing after #508.

This is also aligned with the other recipes' shebangs.

## Checklist

- [X] Ran `just run-all`
