### PR TITLE
docs: :pencil2: match design output with actual output

### DIFF
--- a/vignettes/design.qmd
+++ b/vignettes/design.qmd
@@ -133,7 +133,7 @@ registers and a few helper pre-processing functions.
 ### `classify_diabetes()`
 
 This function classifies those with diabetes (type 1 or 2) based on the
-Danish registers described in the `vignette("design")` and
+Danish registers described in this vignette and
 `vignette("data-sources")`. All data sources needed by osdc are used as
 input for this function. The specific details of the classification
 algorithm are described in the `vignette("algorithm")`.
@@ -150,7 +150,7 @@ registers() |>
   cat(sep = "\n")
 ```
 
-The output is a DuckDB object which includes four columns:
+The output is a DuckDB object with four columns:
 
 - **pnr**: The pseudonymised social security number of individuals in
   the diabetes population (one row per individual).

--- a/vignettes/design.qmd
+++ b/vignettes/design.qmd
@@ -128,14 +128,15 @@ rules.
 
 The osdc package contains one main function that classifies individuals
 into those with either type 1 or type 2 diabetes using the Danish
-registers: `classify_diabetes()`. This function classifies those with
-diabetes (type 1 or 2) based on the Danish registers described in the
-`vignette("design")` and `vignette("data-sources")`. All data sources
-needed by osdc are used as input for this function. The specific details
-of the classification algorithm are described in the
-`vignette("algorithm")`.
+registers and a few helper pre-processing functions.
 
-### Input
+### `classify_diabetes()`
+
+This function classifies those with diabetes (type 1 or 2) based on the
+Danish registers described in the `vignette("design")` and
+`vignette("data-sources")`. All data sources needed by osdc are used as
+input for this function. The specific details of the classification
+algorithm are described in the `vignette("algorithm")`.
 
 There is one argument in `classify_diabetes()` for each required
 register. The names and descriptions of these arguments are as follows:
@@ -144,14 +145,12 @@ register. The names and descriptions of these arguments are as follows:
 #| output: asis
 #| echo: false
 registers() |>
-  purrr::imap_chr(~ glue::glue("- `{.y}`: The register called '{.x$name}' in Danish.")) |>
+  purrr::imap_chr(~ glue::glue("- `{.y}`: The register or set of registers called '{.x$name}' in Danish.")) |>
   unname() |>
   cat(sep = "\n")
 ```
 
-### Output
-
-The output is a `data.frame` type object which includes four columns:
+The output is a DuckDB object which includes four columns:
 
 - **pnr**: The pseudonymised social security number of individuals in
   the diabetes population (one row per individual).
@@ -161,7 +160,10 @@ The output is a `data.frame` type object which includes four columns:
 - **raw_inclusion_date**: The *raw* inclusion date (i.e., the date of
   the second inclusion event as described in the
   `vignette("algorithm")`).
-- **diabetes_type**: The classified diabetes type.
+- **has_t1d**: A logical column indicating whether the individual has
+  type 1 diabetes.
+- **has_t2d**: A logical column indicating whether the individual has
+  type 2 diabetes.
 
 [^1]: For more information on the "raw" versus "stable" inclusion date,
     see `vignette("algorithm")`.


### PR DESCRIPTION
This was out-dated, so I updated it.

## Checklist

- [x] Ran `just run-all`
