### PR TITLE
fix: 🐛 fully use SQL in `yyww_to_yyyymmdd()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     cli,
     codeCollection,
     dplyr (>= 1.2.0),
-    duckplyr (>= 1.1.3),
+    dbplyr (>= 2.5.1),
     fabricatr,
     lifecycle,
     lubridate (>= 1.9.5),
@@ -48,7 +48,7 @@ Suggests:
     testthat (>= 3.0.0),
     tidyr,
     tibble,
-    dbplyr (>= 2.5.1),
+    duckplyr (>= 1.1.3),
     arrow (>= 22.0.0.1)
 VignetteBuilder: 
     quarto

--- a/R/keep.R
+++ b/R/keep.R
@@ -121,9 +121,6 @@ keep_hba1c <- function(lab_forsker) {
 #' dates of all diabetes-specific podiatrist services. Removes duplicate
 #' services on the same date.
 #'
-#' The output is passed to the [join_inclusions()] function for the final
-#' step of the inclusion process.
-#'
 #' @param sysi The SYSI register.
 #' @param sssy The SSSY register.
 #'
@@ -133,7 +130,7 @@ keep_hba1c <- function(lab_forsker) {
 #'   -  `date`: The dates of the first and second diabetes-specific
 #'      podiatrist record
 #'
-#' @keywords @noRd
+#' @noRd
 #' @inherit algorithm seealso
 keep_podiatrist_services <- function(sysi, sssy) {
   logic <- logic_as_expression("is_podiatrist_services")[[1]]
@@ -174,7 +171,7 @@ keep_podiatrist_services <- function(sysi, sssy) {
 #' @param data A DuckDB-backed data frame with a `date` column formatted as YYWW values.
 #'
 #' @returns a data frame containing a `date` column in the format YYYY-MM-DD.
-#' @keywords @noRd
+#' @noRd
 yyww_to_yyyymmdd <- function(data) {
   data |>
     # Ensure input from the honuge/date variable is zero-padded to length 4.

--- a/R/keep.R
+++ b/R/keep.R
@@ -121,6 +121,9 @@ keep_hba1c <- function(lab_forsker) {
 #' dates of all diabetes-specific podiatrist services. Removes duplicate
 #' services on the same date.
 #'
+#' The output is passed to the [join_inclusions()] function for the final
+#' step of the inclusion process.
+#'
 #' @param sysi The SYSI register.
 #' @param sssy The SSSY register.
 #'
@@ -130,7 +133,7 @@ keep_hba1c <- function(lab_forsker) {
 #'   -  `date`: The dates of the first and second diabetes-specific
 #'      podiatrist record
 #'
-#' @noRd
+#' @keywords @noRd
 #' @inherit algorithm seealso
 keep_podiatrist_services <- function(sysi, sssy) {
   logic <- logic_as_expression("is_podiatrist_services")[[1]]
@@ -151,23 +154,14 @@ keep_podiatrist_services <- function(sysi, sssy) {
     dplyr::distinct() |>
     # Keep only the two columns we need.
     dplyr::select(
-      pnr = "pnr",
+      "pnr",
       date = "honuge"
     ) |>
     # Add logical helper variable to indicate diabetes-related podiatrist service.
+    # Transform date from yyww to YYYY-MM-DD.
+    yyww_to_yyyymmdd() |>
+    # Add logical helper variable to indicate diabetes-related podiatrist service.
     dplyr::mutate(from_podiatrist_service = TRUE)
-
-  podiatrist_services |>
-    # Transform `honuge` to YYYY-MM-DD.
-    # Unfortunately, the conversion from YYWW to an actual date is quite tricky
-    # to do well in SQL without a lot of revising and refactoring the code.
-    # So instead, we'll just pull into R, convert, and then bring back
-    # to DuckDB.
-    # TODO: Fix to use DuckDB SQL only.
-    dplyr::collect() |>
-    dplyr::mutate(date = yyww_to_yyyymmdd(.data$date)) |>
-    duckplyr::as_duckdb_tibble(prudence = "stingy") |>
-    duckplyr::as_tbl()
 }
 
 #' Convert date format YYWW to YYYY-MM-DD
@@ -177,34 +171,67 @@ keep_podiatrist_services <- function(sysi, sssy) {
 #' has been removed. This can e.g., happen if the input was "0107" and has been
 #' converted to a numeric 107.
 #'
-#' @param yyww Character(s) of the format YYWW.
+#' @param data A DuckDB-backed data frame with a `date` column formatted as YYWW values.
 #'
-#' @returns Date(s) in the format YYYY-MM-DD.
-#' @noRd
-yyww_to_yyyymmdd <- function(yyww) {
-  if (is.numeric(yyww)) {
-    # Ensure input is zero-padded to length 4.
-    yyww <- sprintf("%04d", yyww)
-  }
+#' @returns a data frame containing a `date` column in the format YYYY-MM-DD.
+#' @keywords @noRd
+yyww_to_yyyymmdd <- function(data) {
+  data |>
+    # Ensure input from the honuge/date variable is zero-padded to length 4.
+    dplyr::mutate(
+      yyww_padded = dbplyr::sql("LPAD(CAST(date AS VARCHAR), 4, '0')"),
+      # Extract year and week.
+      # The way the year values are set up in the registers isn't Y2K-safe,
+      # and by 2090 the values will overflow, and the data will be invalid.
+      # There is nothing we can do about it, but DST will have to deal with it
+      # at some point before 2090.
+      yy = as.integer(substr(.data$yyww_padded, 1, 2)),
+      ww = as.integer(substr(.data$yyww_padded, 3, 4)),
+      full_year = dplyr::if_else(
+        # Anything greater than YY 90 will be from the 1900s.
+        .data$yy >= 90,
+        # Place these in the 1990s.
+        1900L + .data$yy,
+        # Place any values below 90 in the 2000s.
+        2000L + .data$yy
+      ),
+      # Calculate the first day of the ISO year, which is when the first week
+      # has most of the week days in it (4th of January, or the first Thursday).
+      # See https://en.wikipedia.org/wiki/ISO_week_date.
+      jan4 = dbplyr::sql("MAKE_DATE(full_year, 1, 4)"),
+      # Calculate the weekday of jan4 and the date of Monday of ISO-week 1.
+      days_from_monday = dbplyr::sql("(DAYOFWEEK(jan4) + 6) % 7"),
+      week1_monday = dbplyr::sql(
+        "jan4 - (days_from_monday || ' days')::INTERVAL"
+      )
+    ) |>
+    # Calculate the date of the Monday of the ISO week (`ww`)
+    # Starting from `week1_monday` (the Monday of ISO week 1),
+    # add (`ww-1`) weeks to reach the target week:
+    # - `ww-1`: Number of weeks to offset from ISO week 1
 
-  # Extract year and week.
-  year <- stringr::str_sub(yyww, 1, 2)
-  week <- stringr::str_sub(yyww, 3, 4)
+    # - || ' weeks': Concatenates the offset with the text "weeks" to form a SQL interval string (e.g., "3 weeks")
 
-  # Calculate the first day of the ISO year, which is when the first week
-  # has most of the week days in it (4th of January, or the first Thursday).
-  # See: https://en.wikipedia.org/wiki/ISO_week_date
-  year_start <- as.Date(paste0(year, "-01-04"), tryFormats = "%y-%m-%d")
-  first_weekday <- lubridate::wday(year_start, week_start = 1)
+    # - ::INTERVAL: Casts the string to an INTERVAL type.
 
-  # Create the date, using the start of year, but setting the week from the
-  # `yyww` argument. This forces the date to move to the correct week.
-  date <- year_start
-  lubridate::week(date) <- as.numeric(week)
-
-  # Adjust the date to be Monday in that week. Need to add 1 since there is
-  # no zero weekday (week starts on 1, the Monday).
-  date - first_weekday + 1
+    # The result is added to `week1_monday` and cast to DATE.
+    dplyr::mutate(
+      date = dbplyr::sql(
+        "CAST(week1_monday + ((ww - 1) || ' weeks')::INTERVAL AS DATE)"
+      )
+    ) |>
+    # Drop intermediate calculation columns.
+    dplyr::select(
+      -c(
+        "yyww_padded",
+        "yy",
+        "ww",
+        "full_year",
+        "jan4",
+        "days_from_monday",
+        "week1_monday"
+      )
+    )
 }
 
 #' Keep two earliest events per PNR

--- a/tests/testthat/test-yyww-to-yyyymmdd.R
+++ b/tests/testthat/test-yyww-to-yyyymmdd.R
@@ -1,12 +1,35 @@
 test_that("date correctly converts to real dates for end and start of year", {
   # Using real dates from https://en.wikipedia.org/wiki/ISO_week_date
+  input <- data.frame(
+    date = c("0701", "0953", "0852")
+  ) |>
+    duckplyr::as_duckdb_tibble() |>
+    duckplyr::as_tbl()
+
   expected <- lubridate::ymd("2007-01-01", "2009-12-28", "2008-12-22")
-  actual <- yyww_to_yyyymmdd(c("0701", "0953", "0852"))
+
+  actual <- input |>
+    yyww_to_yyyymmdd() |>
+    dplyr::collect() |>
+    dplyr::pull("date")
+
   expect_equal(expected, actual)
 })
 
 test_that("conversion works when date is numeric", {
   # This could happen if the input was "0107" and has been converted to numeric
-  expect_equal(yyww_to_yyyymmdd(107), lubridate::ymd("2001-02-12"))
-  expect_equal(yyww_to_yyyymmdd(7), lubridate::ymd("2000-02-14"))
+  input_numeric <- data.frame(
+    date = c("701", "953", "852")
+  ) |>
+    duckplyr::as_duckdb_tibble() |>
+    duckplyr::as_tbl()
+
+  expected <- lubridate::ymd("2007-01-01", "2009-12-28", "2008-12-22")
+
+  actual_from_numeric <- input_numeric |>
+    yyww_to_yyyymmdd() |>
+    dplyr::collect() |>
+    dplyr::pull(.data$date)
+
+  expect_equal(expected, actual_from_numeric)
 })


### PR DESCRIPTION
This is a clean PR from main identical to #498 but with meaningful diffs.

Avoids fallback to R during keep_podiatrist_services()and potential DuckDB connection source errors during subsequent joins depending on the input data connection sources.

Closes #480