### PR TITLE
build: :technologist: add `quiet=FALSE` to `just build-website`

### DIFF
--- a/justfile
+++ b/justfile
@@ -89,7 +89,7 @@ lint:
 # Build the pkgdown website
 build-website:
   #!/usr/bin/env Rscript
-  pkgdown::build_site()
+  pkgdown::build_site(quiet = FALSE)
 
 # Run local CRAN checks
 check-local-cran:


### PR DESCRIPTION
To help with debugging when build fails.
