### PR TITLE
chore: :technologist: add `.rumdl-cache` to `.Rbuildignore`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -24,3 +24,4 @@
 ^CITATION.cff$
 ^cran-comments\.md$
 ^\.rumdl\.toml$
+^\.rumdl_cache$


### PR DESCRIPTION
I started getting CRAN notes when running checks locally bc of rumdl caches, so I think we should ignore them.