### PR TITLE
build: :woman_technologist: add `install-package` to `just run-all`

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
     just --list --unsorted
 
 # Run all recipes
-run-all: clean install-deps document check-spelling check-urls format-r format-md lint test build-website check-local-cran install-package
+run-all: clean install-deps install-package document check-spelling check-urls format-r format-md lint test build-website check-local-cran install-package
 
 # List all TODO items in the repository
 list-todos:


### PR DESCRIPTION
I've encountered some errors when running `just run-all` that were resolved after running `just install-package`, so I thought it would make sense to just add it to `run-all`.

## Checklist

- [X] Ran `just run-all`
