### PR TITLE
docs: :pencil2: `LPRs` -> `LPR`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,8 @@ standard.
 
 ### Refactor
 
-- ♻️ expose `prepare_lpr*()`; make `classify_diabetes()` expect `lpr` (#532)
+- ♻️ expose `prepare_lpr*()`; make `classify_diabetes()` expect `lpr`
+  (#532)
 
 ## 0.10.0 (2026-04-16)
 

--- a/vignettes/design.qmd
+++ b/vignettes/design.qmd
@@ -149,7 +149,7 @@ created a new LPR (LPR3A) that resolves some issues with the previous
 LPR registers. Each version of LPR contains different tables and
 variables, though osdc only needs specific variables from two tables.
 
-We originally required each original LPRs register as separate arguments
+We originally required each original LPR register as separate arguments
 in `classify_diabetes()`, but this became an issue after the new LPR3A
 was created. So, we re-designed `classify_diabetes()` to take only one
 `lpr` argument and instead require the different LPRs be pre-processed


### PR DESCRIPTION
Noticed this typo.

Needs no review.

## Checklist

- [X] Ran `just run-all`
