### PR TITLE
fix: :adhesive_bandage: remove `start_year` from `joined_registers()` `lpr`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,8 @@ standard.
 
 ### Refactor
 
-- ♻️ expose `prepare_lpr*()`; make `classify_diabetes()` expect `lpr` (#532)
+- ♻️ expose `prepare_lpr*()`; make `classify_diabetes()` expect `lpr`
+  (#532)
 
 ## 0.10.0 (2026-04-16)
 

--- a/R/registers.R
+++ b/R/registers.R
@@ -181,7 +181,7 @@ joined_registers <- function() {
   list(
     lpr = list(
       name = "Landspatientregisteret",
-      start_year = 1977,
+      start_year = NA,
       end_year = NA,
       # TODO: Add which variables all variables come from (LPR2, LPR3F, LPR3A).
       variables = tibble::tribble(


### PR DESCRIPTION
Since the lpr could be any combination of lpr2, lpr3f, and/or lpr3a, we can't know the start year.
