### PR TITLE
docs: :memo: note on LPR3A pre-processing in vignette

### DIFF
--- a/vignettes/osdc.qmd
+++ b/vignettes/osdc.qmd
@@ -277,15 +277,23 @@ lpr3f_diagnoser <- lpr3f_diagnoser |>
   dplyr::compute()
 ```
 
-Most inputs will work in the Arrow/DuckDB type equivalent to their
-original type in the raw SAS file, so unless the SAS-to-Arrow conversion
-introduced unexpected types, you should should not need to do much
-type-conversion at this stage. The `kont_starttidspunkt` in `lpr3a` is
-an important exception, however, as it's raw `datetime` format needs to
-be formatted as a `date` before being input to the classification
-pipeline. Fortunately, this can be done in a single call to
-`dplyr::mutate(as.Date(kont_starttidspunkt))` during pre-processing in
-arrow, e.g.:
+::: callout-important
+Important notes on using `lpr3a` data!
+
+A: `lpr3a` contains duplicates of contacts in 2017 & 2018 that are also
+contained in `lpr2`. These rows must be filtered out before being input
+to osdc's `prepare_lpr3a()` function.
+
+B: The `kont_starttidspunkt` variable in `lpr3a` is a `datetime` type,
+and must be converted to a `date` before being input to
+`prepare_lpr3a()`.
+:::
+
+The duplicate rows in `lpr3a_kontakt` can be removed during processing
+by filtering to `indberetningssystem == "LPR3"` Similarly, the
+`kont_starttidspunkt` variable in `lpr3a` can be converted to a `date`
+in a single call to `dplyr::mutate(as.Date(kont_starttidspunkt))` during
+pre-processing in arrow. e.g.:
 
 ``` r
 lpr3a_kontakt <- "path/to/lpr3a_kontakt_parquet_folder" |>
@@ -293,12 +301,12 @@ lpr3a_kontakt <- "path/to/lpr3a_kontakt_parquet_folder" |>
   arrow::to_duckdb() |>
   # dplyr::select(...) |>
   dplyr::mutate(kont_starttidspunkt = as.Date(kont_starttidspunkt)) |>
-  # dplyr::filter(...) |>
+  dplyr::filter(indberetningssystem == "LPR3") |>
   arrow::to_duckdb(con = ddb_con) |>
   dplyr::compute()
 ```
 
-Which can then be used as input:
+This can be used as input to `prepare_lpr3a()`:
 
 ``` r
 lpr <- list(
@@ -308,6 +316,11 @@ lpr <- list(
 ) |>
   join_registers()
 ```
+
+Most inputs will work in the Arrow/DuckDB equivalent of their type in
+the original SAS file. Unless the SAS-to-Arrow conversion introduced
+unexpected types, you should should not need to do any further type
+conversion.
 
 Once you're done using DuckDB, you should close the driver and
 connection like so:

--- a/vignettes/osdc.qmd
+++ b/vignettes/osdc.qmd
@@ -257,14 +257,56 @@ rename variables or convert their types to match the inputs expected by
 osdc, you can do that too:
 
 ``` r
-diagnoser <- "path/to/diagnoser_parquet_folder" |>
+lpr3f_diagnoser <- "path/to/lpr3f_diagnoser_parquet_folder" |>
   arrow::open_dataset(unify_schemas = TRUE) |>
   arrow::to_duckdb() |>
   # Insert dplyr filtering and variable selection/renaming steps here, e.g.:
   # dplyr::select(...) |>
+  # dplyr::mutate(...) |>
   # dplyr::filter(...) |>
   arrow::to_duckdb(con = ddb_con) |>
   dplyr::compute()
+```
+
+If your data (or parts of it) is already in R (e.g., as a `data.frame`),
+you can convert it to a DuckDB table with:
+
+``` r
+lpr3f_diagnoser <- lpr3f_diagnoser |>
+  arrow::to_duckdb(con = ddb_con) |>
+  dplyr::compute()
+```
+
+Most inputs will work in the Arrow/DuckDB type equivalent to their
+original type in the raw SAS file, so unless the SAS-to-Arrow conversion
+introduced unexpected types, you should should not need to do much
+type-conversion at this stage. The `kont_starttidspunkt` in `lpr3a` is
+an important exception, however, as it's raw `datetime` format needs to
+be formatted as a `date` before being input to the classification
+pipeline. Fortunately, this can be done in a single call to
+`dplyr::mutate(as.Date(kont_starttidspunkt))` during pre-processing in
+arrow, e.g.:
+
+``` r
+lpr3a_kontakt <- "path/to/lpr3a_kontakt_parquet_folder" |>
+  arrow::open_dataset(unify_schemas = TRUE) |>
+  arrow::to_duckdb() |>
+  # dplyr::select(...) |>
+  dplyr::mutate(kont_starttidspunkt = as.Date(kont_starttidspunkt)) |>
+  # dplyr::filter(...) |>
+  arrow::to_duckdb(con = ddb_con) |>
+  dplyr::compute()
+```
+
+Which can then be used as input:
+
+``` r
+lpr <- list(
+  prepare_lpr2(lpr_adm, lpr_diag),
+  prepare_lpr3f(lpr3f_kontakter, lpr3f_diagnoser),
+  prepare_lpr3a(lpr3a_kontakt, lpr3a_diagnose)
+) |>
+  join_registers()
 ```
 
 Once you're done using DuckDB, you should close the driver and
@@ -273,15 +315,6 @@ connection like so:
 ``` r
 duckdb::duckdb_shutdown(ddb_driver)
 DBI::dbDisconnect(ddb_con)
-```
-
-If your data is already in R (e.g., as a data frame), you can convert it
-to a DuckDB table with:
-
-``` r
-diagnoser <- diagnoser |>
-  arrow::to_duckdb() |>
-  dplyr::compute()
 ```
 
 ## Getting help

--- a/vignettes/osdc.qmd
+++ b/vignettes/osdc.qmd
@@ -259,7 +259,6 @@ osdc, you can do that too:
 ``` r
 lpr3f_diagnoser <- "path/to/lpr3f_diagnoser_parquet_folder" |>
   arrow::open_dataset(unify_schemas = TRUE) |>
-  arrow::to_duckdb() |>
   # Insert dplyr filtering and variable selection/renaming steps here, e.g.:
   # dplyr::select(...) |>
   # dplyr::mutate(...) |>
@@ -292,13 +291,12 @@ and must be converted to a `date` before being input to
 The duplicate rows in `lpr3a_kontakt` can be removed during processing
 by filtering to `indberetningssystem == "LPR3"` Similarly, the
 `kont_starttidspunkt` variable in `lpr3a` can be converted to a `date`
-in a single call to `dplyr::mutate(as.Date(kont_starttidspunkt))` during
-pre-processing in arrow. e.g.:
+in a single call to `dplyr::mutate()` during
+pre-processing in Arrow. e.g.:
 
 ``` r
 lpr3a_kontakt <- "path/to/lpr3a_kontakt_parquet_folder" |>
   arrow::open_dataset(unify_schemas = TRUE) |>
-  arrow::to_duckdb() |>
   # dplyr::select(...) |>
   dplyr::mutate(kont_starttidspunkt = as.Date(kont_starttidspunkt)) |>
   dplyr::filter(indberetningssystem == "LPR3") |>


### PR DESCRIPTION
Updates the "working with real data"-section of the Getting Started vignette to match recent changes to lpr3 registers. 

Also adds a note/example of the required pre-processing steps for lpr3a (datetime-to-date conversion of `kont_starttidspunkt` to match expected input and filtering to `indberetningskilde == "LPR3"` to remove potential duplicates).

Closes #544

## Checklist

- [x] Ran `just run-all`
