### PR TITLE
fix: :heavy_plus_sign: moved duckplyr dependency to Import to fix error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
     codeCollection,
     dplyr (>= 1.2.0),
     dbplyr (>= 2.5.1),
+    duckplyr (>= 1.1.3),
     fabricatr,
     lifecycle,
     lubridate (>= 1.9.5),
@@ -49,7 +50,6 @@ Suggests:
     tidyr,
     tibble,
     arrow (>= 22.0.0.1),
-    duckplyr (>= 1.1.3),
     DBI (>= 1.3.0)
 VignetteBuilder:
     quarto
@@ -57,4 +57,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/R/osdc-package.R
+++ b/R/osdc-package.R
@@ -17,9 +17,11 @@ NULL
 # For more details, see https://rlang.r-lib.org/reference/dot-data.html#where-does-data-live
 utils::globalVariables(".data")
 
+# jarl-ignore-start unused_function: use duckplyr in examples and vignettes and to avoid CRAN error on some runners.
 # Suppress R CMD check note
 # Namespace in Imports field not imported from: PKG
 #   All declared Imports should be used.
 ignore_unused_imports <- function() {
   duckplyr::as_duckdb_tibble
 }
+# jarl-ignore-end unused_function

--- a/R/osdc-package.R
+++ b/R/osdc-package.R
@@ -16,3 +16,10 @@ NULL
 # since CRAN doesn't know that packages like dplyr use NSE.
 # For more details, see https://rlang.r-lib.org/reference/dot-data.html#where-does-data-live
 utils::globalVariables(".data")
+
+# Suppress R CMD check note
+# Namespace in Imports field not imported from: PKG
+#   All declared Imports should be used.
+ignore_unused_imports <- function() {
+  duckplyr::as_duckdb_tibble
+}

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,3 +1,4 @@
+osdc's
 Aarhus
 BEF
 CMD

--- a/man/osdc-package.Rd
+++ b/man/osdc-package.Rd
@@ -24,6 +24,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Luke William Johnston \email{lwjohnst@gmail.com} (\href{https://orcid.org/0000-0003-4169-2616}{ORCID})
   \item Signe Kirk Brødbæk \email{signekb@clin.au.dk} (\href{https://orcid.org/0009-0000-2208-7088}{ORCID})
   \item Anders Aasted Isaksen \email{andaas@rm.dk} (\href{https://orcid.org/0000-0001-8457-5466}{ORCID})
 }


### PR DESCRIPTION
One of CRANs OS runners has an error that duckplyr can't be found since it isn't installed. So this moves it up to be installed. Also makes sense since our examples and our vignettes use it.

## Checklist

- [x] Ran `just run-all`
