### PR TITLE
ci: :construction_worker: pin workflows to specific commits

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
   release:
-    types: [ published ]
+    types: [published]
 
 permissions: read-all
 
@@ -18,16 +18,16 @@ jobs:
     name: format-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install
-        uses: posit-dev/setup-air@v1
+        uses: posit-dev/setup-air@cf390573ff4fe0f198f35df3a642b1409328d859 # v1
 
       - name: Check
         run: air format . --check
 
       - name: Lint
-        uses: etiennebacher/setup-jarl@v0.1.0
+        uses: etiennebacher/setup-jarl@eabf7e572f2991d165059007531b9bbe2987e39c # v0.1.1
 
   cran-checks:
     runs-on: ${{ matrix.config.os }}
@@ -50,28 +50,28 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-pandoc@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2
         with:
           extra-packages: any::rcmdcheck, local::.
           needs: |
             check
             tests
 
-      - uses: r-lib/actions/check-r-package@v2
+      - uses: r-lib/actions/check-r-package@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2
         with:
           upload-snapshots: true
-          build_args: "c(\"--no-manual\",\"--compact-vignettes=gs+qpdf\")"
-          error-on: "\"note\""
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
+          error-on: '"note"'
 
   pkgdown:
     uses: ./.github/workflows/reusable-pkgdown.yaml


### PR DESCRIPTION
Some of the workflows were outdated, so this updates them.

No review needed.
