### PR TITLE
build: :hammer: always upgrade when installing deps

### DIFF
--- a/justfile
+++ b/justfile
@@ -38,7 +38,8 @@ install-deps:
     dependencies = c(
       "all"
     ),
-    ask = FALSE
+    ask = FALSE,
+    upgrade = TRUE
   )
 
 # Run document generators


### PR DESCRIPTION
This avoids/minimises risk when running remote CRAN checks.

No review needed.